### PR TITLE
Default values for gates that are added to a circuit

### DIFF
--- a/maskit/masks.py
+++ b/maskit/masks.py
@@ -300,11 +300,11 @@ class MaskedCircuit(object):
             return
         np_indices = tuple(zip(*indices))
         if not np.all(mask.mask[np_indices]):
-            if self.wire_mask == mask:
+            if self.wire_mask is mask:
                 self.parameters[:, np_indices] = self.default_value
-            elif self.layer_mask == mask:
+            elif self.layer_mask is mask:
                 self.parameters[np_indices, :] = self.default_value
-            elif self.parameter_mask == mask:
+            elif self.parameter_mask is mask:
                 self.parameters[np_indices] = self.default_value
             else:
                 raise NotImplementedError(f"The mask {mask} is not supported")


### PR DESCRIPTION
This pull requests implements the functionality to define a `default_value` for parameters. In case a parameter is added back into a circuit, either manually or via functions `prune` or `shrink`, the parameter can take a specified `default_value` in case it is defined for the `MaskedCircuit`.

This PR also includes relevant unit tests.

Fixes #14.