### PR TITLE
Add L-BFGS-B optimiser

### DIFF
--- a/main.py
+++ b/main.py
@@ -81,7 +81,11 @@ def train(
     layers = train_params["layers"]
     steps = train_params.get("steps", 1000)
     dev = get_device(train_params.get("sim_local", True), wires=wires)
-    opt = train_params["optimizer"].value(train_params["step_size"])
+    step_size = train_params.get("step_size", None)
+    if step_size:
+        opt = train_params["optimizer"].value(step_size)
+    else:
+        opt = train_params["optimizer"].value()
     dropout_ensemble = train_params.get("ensemble_type", Ensemble)(
         **train_params.get("ensemble_kwargs", {"dropout": None})
     )

--- a/maskit/ensembles.py
+++ b/maskit/ensembles.py
@@ -60,8 +60,8 @@ class Ensemble(object):
         # first one trainingstep
         params, _cost, _gradient = optimizer.step_cost_and_grad(
             objective_fn,
-            *args,
             masked_circuit.parameters,
+            *args,
             masked_circuit=masked_circuit,
         )
         masked_circuit.parameters = params

--- a/maskit/masks.py
+++ b/maskit/masks.py
@@ -347,13 +347,9 @@ class MaskedCircuit(object):
 
         :param changed_parameters: Current set of differentiable parameters
         """
-        if (
-            changed_parameters.size == self.parameters.size
-            and len(changed_parameters.shape) > 1
-        ):
-            return changed_parameters
+        flattened_changed_parameters = changed_parameters.flatten()
         result = self.parameters.astype(object)
-        result[~self.mask] = changed_parameters
+        result[~self.mask] = flattened_changed_parameters
         return result
 
     @staticmethod

--- a/maskit/masks.py
+++ b/maskit/masks.py
@@ -347,6 +347,11 @@ class MaskedCircuit(object):
 
         :param changed_parameters: Current set of differentiable parameters
         """
+        if (
+            changed_parameters.size == self.parameters.size
+            and len(changed_parameters.shape) > 1
+        ):
+            return changed_parameters
         result = self.parameters.astype(object)
         result[~self.mask] = changed_parameters
         return result

--- a/maskit/masks.py
+++ b/maskit/masks.py
@@ -347,9 +347,8 @@ class MaskedCircuit(object):
 
         :param changed_parameters: Current set of differentiable parameters
         """
-        flattened_changed_parameters = changed_parameters.flatten()
         result = self.parameters.astype(object)
-        result[~self.mask] = flattened_changed_parameters
+        result[~self.mask] = changed_parameters.flatten()
         return result
 
     @staticmethod

--- a/maskit/optimizers.py
+++ b/maskit/optimizers.py
@@ -1,5 +1,122 @@
+from typing import Tuple
 from pennylane import GradientDescentOptimizer, AdamOptimizer
+from pennylane._grad import grad as get_gradient
 from enum import Enum
+from pennylane.numpy import ndarray
+import scipy.optimize as sciopt
+
+
+class L_BFGS_B:
+    __slots__ = (
+        "bounds",
+        "m",
+        "factr",
+        "pgtol",
+        "epsilon",
+        "iprint",
+        "maxfun",
+        "maxiter",
+        "disp",
+        "callback",
+        "maxls",
+    )
+
+    def __init__(
+        self,
+        bounds=None,
+        m: int = 10,
+        factr: float = 1e7,  # qiskit: factr: float = 10,
+        pgtol: float = 1e-5,
+        epsilon: float = 1e-8,  # qiskit: epsilon: float = 1e-08,
+        iprint: int = -1,  # qiskit: iprint: int = -1,
+        maxfun: int = 15000,  # qiskit: maxfun: int = 1000,
+        maxiter: int = 15000,  # qiskit: maxiter: int = 15000,
+        disp=None,
+        callback=None,
+        maxls: int = 20,
+    ):
+        """
+        In case the method :py:method:`~.step` is used, the value of parameter
+        `maxiter` is ignored and interpreted as `1` instead.
+
+        :param bounds: [description], defaults to None
+        :param m: [description], defaults to 10
+        :param factr: [description], defaults to 1e7
+        :param pgtol: [description], defaults to 1e-5
+        :param epsilon: [description], defaults to 1e-8
+        :param iprint: [description], defaults to -1
+        :param maxfun: [description], defaults to 15000
+        :param maxiter: [description], defaults to 15000
+        :param disp: [description], defaults to None
+        :param callback: [description], defaults to None
+        :param maxls: [description], defaults to 20
+        """
+        self.bounds = bounds
+        self.m = m
+        self.factr = factr
+        self.pgtol = pgtol
+        self.epsilon = epsilon
+        self.iprint = iprint
+        self.maxfun = maxfun
+        self.maxiter = maxiter
+        self.disp = disp
+        self.callback = callback
+        self.maxls = maxls
+
+    def optimize(
+        self,
+        objective_fn,
+        parameters: ndarray,
+        *args,
+        grad_fn=None,
+        **kwargs,
+    ):
+        return self._optimise(
+            objective_fn, parameters, self.maxiter, *args, grad_fn=grad_fn, **kwargs
+        )
+
+    def _optimise(
+        self, objective_fn, parameters: ndarray, maxiter, *args, grad_fn, **kwargs
+    ):
+        shape = parameters.shape
+        shaped_fn = self._wrap_objective_fn(objective_fn, shape, **kwargs)
+        approx_grad = False  # TODO: check the defaults of pennylane optimisers
+        sol, opt, info = sciopt.fmin_l_bfgs_b(
+            shaped_fn,
+            parameters.flatten(),
+            bounds=self.bounds,
+            fprime=get_gradient(shaped_fn) if grad_fn is None else grad_fn,
+            approx_grad=approx_grad,
+            maxiter=1,
+        )
+        return sol.reshape(shape), opt, info["grad"]
+
+    def _wrap_objective_fn(self, objective_fn, shape, **kwargs):
+        return lambda params, *args: objective_fn(
+            params.reshape(shape), *args, **kwargs
+        )
+
+    def step(self, objective_fn, parameters, *args, grad_fn=None, **kwargs) -> ndarray:
+        sol, _, _ = self._optimise(
+            objective_fn, parameters, 1, *args, grad_fn=grad_fn, **kwargs
+        )
+        return sol
+
+    def step_and_cost(
+        self, objective_fn, parameters, *args, grad_fn=None, **kwargs
+    ) -> Tuple[ndarray, float]:
+        sol, cost, _ = self._optimise(
+            objective_fn, parameters, 1, *args, grad_fn=grad_fn, **kwargs
+        )
+        return sol, cost
+
+    def step_cost_and_grad(
+        self, objective_fn, parameters, *args, grad_fn=None, **kwargs
+    ):
+        sol, cost, grad = self._optimise(
+            objective_fn, parameters, 1, *args, grad_fn=grad_fn, **kwargs
+        )
+        return sol, cost, grad
 
 
 class ExtendedGradientDescentOptimizer(GradientDescentOptimizer):
@@ -32,3 +149,4 @@ class ExtendedAdamOptimizer(ExtendedGradientDescentOptimizer, AdamOptimizer):
 class ExtendedOptimizers(Enum):
     GD = ExtendedGradientDescentOptimizer
     ADAM = ExtendedAdamOptimizer
+    L_BFGS_B = L_BFGS_B

--- a/maskit/optimizers.py
+++ b/maskit/optimizers.py
@@ -10,6 +10,26 @@ class L_BFGS_B:
     """
     The L-BFGS-B optimiser provides a wrapper for the implementation provided
     in scipy. Please see the appropriate documentation for further details.
+
+    In case the method :py:method:`~.step` is used, the value of parameter `maxiter`
+    is ignored and interpreted as `1` instead.
+
+    :param bounds: tuple of `min` and `max` for each value of provided parameters,
+        defaults to None
+    :param m: maximum number of variable metric corrections used to define the
+        limited memory matrix, defaults to 10
+    :param factr: information on when to stop iterating, e.g. 1e12 for low accuracy;
+        1e7 for moderate accuracy; 10.0 for extremely high accuracy, defaults to 1e7
+    :param pgtol: when to stop iterating with regards to gradients, defaults to 1e-5
+    :param epsilon: Step size used when `approx_grad` is `True`, defaults to 1e-8
+    :param iprint: Frequency of output, defaults to -1
+    :param maxfun: Maximum number of function evaluations, defaults to 15000
+    :param maxiter: Maximum number of iterations, defaults to 15000
+    :param disp: [description], defaults to None
+    :param callback: Called after each iteration with current parameters,
+        defaults to None
+    :param maxls: Maximum number of line search steps (per iteration),
+        defaults to 20
     """
 
     __slots__ = (
@@ -40,27 +60,6 @@ class L_BFGS_B:
         callback=None,
         maxls: int = 20,
     ):
-        """
-        In case the method :py:method:`~.step` is used, the value of parameter
-        `maxiter` is ignored and interpreted as `1` instead.
-
-        :param bounds: tuple of `min` and `max` for each value of provided parameters,
-            defaults to None
-        :param m: maximum number of variable metric corrections used to define the
-            limited memory matrix, defaults to 10
-        :param factr: information on when to stop iterating, e.g. 1e12 for low accuracy;
-            1e7 for moderate accuracy; 10.0 for extremely high accuracy, defaults to 1e7
-        :param pgtol: when to stop iterating with regards to gradients, defaults to 1e-5
-        :param epsilon: Step size used when `approx_grad` is `True`, defaults to 1e-8
-        :param iprint: Frequency of output, defaults to -1
-        :param maxfun: Maximum number of function evaluations, defaults to 15000
-        :param maxiter: Maximum number of iterations, defaults to 15000
-        :param disp: [description], defaults to None
-        :param callback: Called after each iteration with current parameters,
-            defaults to None
-        :param maxls: Maximum number of line search steps (per iteration),
-            defaults to 20
-        """
         self.bounds = bounds
         self.m = m
         self.factr = factr

--- a/maskit/optimizers.py
+++ b/maskit/optimizers.py
@@ -9,27 +9,25 @@ import scipy.optimize as sciopt
 class L_BFGS_B:
     """
     The L-BFGS-B optimiser provides a wrapper for the implementation provided
-    in scipy. Please see the :py:func:`~sciopt.fmin_l_bfgs_b` documentation for further details.
+    in scipy. Please see the :py:func:`~sciopt.fmin_l_bfgs_b` documentation for
+    further details.
 
     In case the method :py:method:`~.step` is used, the value of parameter `maxiter`
     is ignored and interpreted as `1` instead.
 
-    :param bounds: tuple of `min` and `max` for each value of provided parameters,
-        defaults to None
+    :param bounds: tuple of `min` and `max` for each value of provided parameters
     :param m: maximum number of variable metric corrections used to define the
-        limited memory matrix, defaults to 10
+        limited memory matrix
     :param factr: information on when to stop iterating, e.g. 1e12 for low accuracy;
-        1e7 for moderate accuracy; 10.0 for extremely high accuracy, defaults to 1e7
-    :param pgtol: when to stop iterating with regards to gradients, defaults to 1e-5
-    :param epsilon: Step size used when `approx_grad` is `True`, defaults to 1e-8
-    :param iprint: Frequency of output, defaults to -1
-    :param maxfun: Maximum number of function evaluations, defaults to 15000
-    :param maxiter: Maximum number of iterations, defaults to 15000
-    :param disp: [description], defaults to None
-    :param callback: Called after each iteration with current parameters,
-        defaults to None
-    :param maxls: Maximum number of line search steps (per iteration),
-        defaults to 20
+        1e7 for moderate accuracy; 10.0 for extremely high accuracy
+    :param pgtol: when to stop iterating with regards to gradients
+    :param epsilon: Step size used when `approx_grad` is `True`
+    :param iprint: Frequency of output
+    :param maxfun: Maximum number of function evaluations
+    :param maxiter: Maximum number of iterations
+    :param disp: If zero, then no output. If positive this over-rides `iprint`
+    :param callback: Called after each iteration with current parameters
+    :param maxls: Maximum number of line search steps (per iteration)
     """
 
     __slots__ = (
@@ -84,17 +82,17 @@ class L_BFGS_B:
         :param objective_fn: Function to minimize
         :param parameters: Initial guess of parameters
         :param grad_fn: The gradient of `func`. In case of `None`, the gradient is
-            approximated numerically, defaults to None
+            approximated numerically
         """
-        return self._optimise(
+        return self._optimize(
             objective_fn, parameters, self.maxiter, *args, grad_fn=grad_fn, **kwargs
         )
 
-    def _optimise(
+    def _optimize(
         self, objective_fn, parameters: ndarray, maxiter, *args, grad_fn, **kwargs
     ) -> Tuple[ndarray, float, ndarray]:
         shape = parameters.shape
-        shaped_fn = self._wrap_objective_fn(objective_fn, shape, **kwargs)
+        shaped_fn = self._reshaping_objective_fn(objective_fn, shape, **kwargs)
         approx_grad = False if grad_fn is not None else True
         updated_parameters, cost, info = sciopt.fmin_l_bfgs_b(
             shaped_fn,
@@ -126,12 +124,11 @@ class L_BFGS_B:
         :param objective_fn: Function to minimize
         :param parameters: Initial guess of parameters
         :param grad_fn: The gradient of `func`. In case of `None`, the gradient is
-            approximated numerically, defaults to None
+            approximated numerically
         """
-        updated_parameters, _, _ = self._optimise(
-            objective_fn, parameters, 1, *args, grad_fn=grad_fn, **kwargs
-        )
-        return updated_parameters
+        return self.step_cost_and_grad(
+            objective_fn, parameters, *args, grad_fn=grad_fn, **kwargs
+        )[0]
 
     def step_and_cost(
         self, objective_fn, parameters, *args, grad_fn=None, **kwargs
@@ -140,12 +137,11 @@ class L_BFGS_B:
         :param objective_fn: Function to minimize
         :param parameters: Initial guess of parameters
         :param grad_fn: The gradient of `func`. In case of `None`, the gradient is
-            approximated numerically, defaults to None
+            approximated numerically
         """
-        updated_parameters, cost, _ = self._optimise(
-            objective_fn, parameters, 1, *args, grad_fn=grad_fn, **kwargs
-        )
-        return updated_parameters, cost
+        return self.step_cost_and_grad(
+            objective_fn, parameters, *args, grad_fn=grad_fn, **kwargs
+        )[:2]
 
     def step_cost_and_grad(
         self, objective_fn, parameters, *args, grad_fn=None, **kwargs
@@ -154,9 +150,9 @@ class L_BFGS_B:
         :param objective_fn: Function to minimize
         :param parameters: Initial guess of parameters
         :param grad_fn: The gradient of `func`. In case of `None`, the gradient is
-            approximated numerically, defaults to None
+            approximated numerically
         """
-        updated_parameters, cost, gradients = self._optimise(
+        updated_parameters, cost, gradients = self._optimize(
             objective_fn, parameters, 1, *args, grad_fn=grad_fn, **kwargs
         )
         return updated_parameters, cost, gradients

--- a/maskit/optimizers.py
+++ b/maskit/optimizers.py
@@ -27,10 +27,10 @@ class L_BFGS_B:
         m: int = 10,
         factr: float = 1e7,  # qiskit: factr: float = 10,
         pgtol: float = 1e-5,
-        epsilon: float = 1e-8,  # qiskit: epsilon: float = 1e-08,
-        iprint: int = -1,  # qiskit: iprint: int = -1,
+        epsilon: float = 1e-8,
+        iprint: int = -1,
         maxfun: int = 15000,  # qiskit: maxfun: int = 1000,
-        maxiter: int = 15000,  # qiskit: maxiter: int = 15000,
+        maxiter: int = 15000,
         disp=None,
         callback=None,
         maxls: int = 20,
@@ -70,7 +70,7 @@ class L_BFGS_B:
         *args,
         grad_fn=None,
         **kwargs,
-    ):
+    ) -> Tuple[ndarray, float, ndarray]:
         return self._optimise(
             objective_fn, parameters, self.maxiter, *args, grad_fn=grad_fn, **kwargs
         )
@@ -84,10 +84,20 @@ class L_BFGS_B:
         sol, opt, info = sciopt.fmin_l_bfgs_b(
             shaped_fn,
             parameters.flatten(),
-            bounds=self.bounds,
             fprime=get_gradient(shaped_fn) if grad_fn is None else grad_fn,
+            *args,
             approx_grad=approx_grad,
-            maxiter=1,
+            bounds=self.bounds,
+            m=self.m,
+            factr=self.factr,
+            pgtol=self.pgtol,
+            epsilon=self.epsilon,
+            iprint=self.iprint,
+            maxfun=self.maxfun,
+            maxiter=maxiter,
+            disp=self.disp,
+            callback=self.callback,
+            maxls=self.maxls,
         )
         return sol.reshape(shape), opt, info["grad"]
 

--- a/maskit/optimizers.py
+++ b/maskit/optimizers.py
@@ -9,7 +9,7 @@ import scipy.optimize as sciopt
 class L_BFGS_B:
     """
     The L-BFGS-B optimiser provides a wrapper for the implementation provided
-    in scipy. Please see the appropriate documentation for further details.
+    in scipy. Please see the :py:func:`~sciopt.fmin_l_bfgs_b` documentation for further details.
 
     In case the method :py:method:`~.step` is used, the value of parameter `maxiter`
     is ignored and interpreted as `1` instead.
@@ -116,7 +116,7 @@ class L_BFGS_B:
         )
         return updated_parameters.reshape(shape), cost, info["grad"]
 
-    def _wrap_objective_fn(self, objective_fn, shape, **kwargs):
+    def _reshaping_objective_fn(self, objective_fn, shape, **kwargs):
         return lambda params, *args: objective_fn(
             params.reshape(shape), *args, **kwargs
         )

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -41,6 +41,11 @@ class TestLBFGSBOptimizer:
         assert step_cost < base_cost
         assert final_cost < step_cost
 
+        new_params = optimizer.step(cost_fn, mp_step.parameters)
+        assert pnp.array_equal(params, new_params)
+        new_params, new_cost = optimizer.step_and_cost(cost_fn, new_params)
+        assert new_cost < step_cost
+
     def test_shape(self):
         optimizer = L_BFGS_B()
         original_optimizer = ExtendedGradientDescentOptimizer()

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -1,0 +1,111 @@
+import random
+from tests.configurations import RANDOM
+from maskit.ensembles import Ensemble
+from tests.utils import (
+    plain_cost,
+    cost,
+    create_circuit,
+    device,
+    plain_variational_circuit,
+    variational_circuit,
+)
+from maskit.optimizers import ExtendedGradientDescentOptimizer, L_BFGS_B
+
+import pennylane as qml
+import pennylane.numpy as pnp
+
+
+class TestLBFGSBOptimizer:
+    def test_init(self):
+        optimizer = L_BFGS_B()
+        assert optimizer
+
+    def test_plain(self):
+        optimizer = L_BFGS_B()
+        mp = create_circuit(3, layer_size=2)
+        mp_step = mp.copy()
+        circuit = qml.QNode(plain_variational_circuit, device(mp.wire_mask.size))
+
+        def cost_fn(params):
+            return plain_cost(
+                params,
+                circuit,
+            )
+
+        base_cost = cost_fn(mp.parameters)
+        _params, final_cost, _gradient = optimizer.optimize(cost_fn, mp.parameters)
+        params, step_cost, _gradient = optimizer.step_cost_and_grad(
+            cost_fn, mp_step.parameters
+        )
+        assert final_cost < base_cost
+        assert step_cost < base_cost
+        assert final_cost < step_cost
+
+    def test_shape(self):
+        optimizer = L_BFGS_B()
+        original_optimizer = ExtendedGradientDescentOptimizer()
+        mp = create_circuit(3, layer_size=2)
+        mp_original = mp.copy()
+        circuit = qml.QNode(plain_variational_circuit, device(mp.wire_mask.size))
+
+        def cost_fn(params):
+            return plain_cost(
+                params,
+                circuit,
+            )
+
+        params, _cost, _gradient = optimizer.step_cost_and_grad(cost_fn, mp.parameters)
+        original_params, _cost, _gradient = original_optimizer.step_cost_and_grad(
+            cost_fn, mp_original.parameters
+        )
+        assert mp.parameters.shape == params.shape
+        assert original_params.shape == params.shape
+
+    def test_mask(self):
+        optimizer = L_BFGS_B()
+        mp = create_circuit(3, layer_size=2)
+        mp_step = mp.copy()
+        circuit = qml.QNode(variational_circuit, device(mp.wire_mask.size))
+
+        def cost_fn(params, masked_circuit=None):
+            return cost(
+                params,
+                circuit,
+                masked_circuit=masked_circuit,
+            )
+
+        base_cost = cost_fn(mp.parameters, masked_circuit=mp)
+        _params, final_cost, _gradient = optimizer.optimize(
+            cost_fn, mp.differentiable_parameters, masked_circuit=mp
+        )
+        params, step_cost, _gradient = optimizer.step_cost_and_grad(
+            cost_fn, mp_step.differentiable_parameters, masked_circuit=mp_step
+        )
+        assert final_cost < base_cost
+        assert step_cost < base_cost
+        assert final_cost < step_cost
+
+    def test_ensemble(self):
+        random.seed(1234)
+        pnp.random.seed(1234)
+        optimizer = L_BFGS_B()
+        ensemble = Ensemble(dropout=RANDOM)
+        mp = create_circuit(3, layer_size=2)
+        circuit = qml.QNode(variational_circuit, device(mp.wire_mask.size))
+
+        def cost_fn(params, masked_circuit=None):
+            return cost(
+                params,
+                circuit,
+                masked_circuit=masked_circuit,
+            )
+
+        base_cost = cost_fn(mp.parameters, masked_circuit=mp)
+        for _ in range(5):
+            result = ensemble.step(
+                masked_circuit=mp,
+                optimizer=optimizer,
+                objective_fn=cost_fn,
+                ensemble_steps=1,
+            )
+            assert result.cost < base_cost

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -12,6 +12,10 @@ def cost(params, circuit, masked_circuit: MaskedCircuit) -> float:
     return 1.0 - circuit(params, masked_circuit=masked_circuit)[0]
 
 
+def plain_cost(params, circuit) -> float:
+    return 1.0 - circuit(params)[0]
+
+
 def create_circuit(size: int, layer_size: int = 1):
     if layer_size == 1:
         parameters = pnp.random.uniform(low=-pnp.pi, high=pnp.pi, size=(size, size))
@@ -47,3 +51,17 @@ def variational_circuit(params, masked_circuit: MaskedCircuit = None):
             for wire in range(1, masked_circuit.layer_mask.size - 1, 2):
                 qml.CZ(wires=[wire, wire + 1])
     return qml.probs(wires=range(len(masked_circuit.wire_mask)))
+
+
+def plain_variational_circuit(params):
+    layers = params.shape[0]
+    wires = params.shape[1]
+    for layer in range(layers):
+        for wire in range(wires):
+            qml.RX(params[layer][wire][0], wires=wire)
+            qml.RY(params[layer][wire][1], wires=wire)
+        for wire in range(0, layers - 1, 2):
+            qml.CZ(wires=[wire, wire + 1])
+        for wire in range(1, layers - 1, 2):
+            qml.CZ(wires=[wire, wire + 1])
+    return qml.probs(wires=range(wires))


### PR DESCRIPTION
This PR adds the L-BFGS-B optimiser. The API of the optimiser is designed to be similar to the one defined by PennyLane, so it can easily be used as a drop-in. The functionality of the optimiser is used from the scipy package, so the only thing that is implemented here is the wrapper for PennyLane.