### PR TITLE
Updated pennylane requirement

### DIFF
--- a/main.py
+++ b/main.py
@@ -16,10 +16,10 @@ from maskit.ensembles import (
 )
 
 
-def get_device(sim_local: bool, wires: int, analytic: bool = True):
+def get_device(sim_local: bool, wires: int, shots: Optional[int] = None):
     assert sim_local, "Currently only local simulation is supported"
     if sim_local:
-        dev = qml.device("default.qubit", wires=wires, analytic=analytic)
+        dev = qml.device("default.qubit", wires=wires, shots=shots)
     return dev
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ home-page = "https://github.com/cirKITers/masKIT"
 classifiers = [ "License :: OSI Approved :: MIT License",]
 description-file = "README.md"
 requires = [
-    "pennylane ~= 0.14.1",
+    "pennylane ~= 0.15.0",
     "typing_extensions",
 ]
 


### PR DESCRIPTION
This PR updates the requirement for [PennyLane](https://github.com/PennyLaneAI/pennylane/releases/tag/v0.15.0) to `~= 0.15.0` and adapts the creation of the device in main.py.