### PR TITLE
Log Path adaptation via environment variable

### DIFF
--- a/maskit/log_results.py
+++ b/maskit/log_results.py
@@ -1,4 +1,5 @@
 from typing import List, Dict, TypeVar, Union, Any, Callable
+import os
 import time
 import json
 import pathlib
@@ -11,7 +12,9 @@ JSON = _JSON_Element[_JSON_Element[_JSON_Element[Any]]]
 CJ = TypeVar("CJ", bound=Callable[..., JSON])
 
 
-log_path = pathlib.Path(__file__).parent / "logs" / f"{time.time()}.json"
+log_base_path = os.environ.get("MASKIT_LOG_PATH", pathlib.Path.cwd() / "logs")
+log_file_name = os.environ.get("MASKIT_LOG_FILE_NAME", f"{time.time()}.json")
+log_path = pathlib.Path(log_base_path) / log_file_name
 log_path.parent.mkdir(exist_ok=True)
 
 


### PR DESCRIPTION
The log path was so far set quite statically to be stored within the folder of the package. This is now more flexible in two ways:

* the current working directory is considered as the base path to store the log files in,
* an environment variable `MASKIT_LOG_PATH` can be specified that defines where to store log files.

Further the file name of the log file can be defined via the environment variable `MASKIT_LOG_FILE_NAME`.

This PR closes #20.