### PR TITLE
Enabling presets of masks

### DIFF
--- a/main.py
+++ b/main.py
@@ -169,6 +169,9 @@ def train(
         "final_layers": current_layers,
         "params": masked_circuit.parameters.unwrap(),
         "mask": masked_circuit.mask.unwrap(),
+        "__wire_mask": masked_circuit.wire_mask.mask,
+        "__layer_mask": masked_circuit.layer_mask.mask,
+        "__parameter_mask": masked_circuit.parameter_mask.mask,
         "__rotations": rotations,
     }
 
@@ -176,7 +179,9 @@ def train(
 def test(
     train_params,
     params,
-    mask,
+    wire_mask,
+    layer_mask,
+    parameter_mask,
     layers: int,
     rotations: List,
     test_data: Optional[List] = None,
@@ -191,17 +196,24 @@ def test(
         correct = 0
         N = len(test_data)
         costs = []
-        masked_circuit = MaskedCircuit(parameters=params, layers=layers, wires=wires)
+        masked_circuit = MaskedCircuit(
+            parameters=params,
+            layers=layers,
+            wires=wires,
+            wire_mask=wire_mask,
+            layer_mask=layer_mask,
+            parameter_mask=parameter_mask,
+        )
         for _step, (data, target) in enumerate(zip(test_data, test_target)):
             output = circuit(
-                params,
+                masked_circuit.differentiable_parameters,
                 data,
                 rotations,
                 masked_circuit,
             )
             c = cost_iris(
                 circuit,
-                params,
+                masked_circuit.differentiable_parameters,
                 data,
                 target,
                 rotations,
@@ -274,7 +286,9 @@ if __name__ == "__main__":
         test(
             train_params,
             result["params"],
-            result["mask"],
+            result["__wire_mask"],
+            result["__layer_mask"],
+            result["__parameter_mask"],
             result["final_layers"],
             result["__rotations"],
             test_data=test_data,

--- a/maskit/masks.py
+++ b/maskit/masks.py
@@ -29,6 +29,10 @@ class Mask(object):
     A Mask encapsulates a :py:attr:`~.mask` storing boolean value if a specific value
     is masked or not. In case a specific position is `True`, the according value is
     masked, otherwise it is not.
+
+    :param shape: The shape of the mask
+    :param parent: `MaskedCircuit` that owns the mask
+    :param mask: Preset of values that is taken by mask
     """
 
     __slots__ = ("mask", "_parent")
@@ -179,6 +183,15 @@ class MaskedCircuit(object):
     """
     A MaskedCircuit supports masking of different components including wires, layers,
     and parameters.
+
+    :param parameters: Initial parameter set for circuit
+    :param layers: Number of layers
+    :param wires: Number of wires
+    :param default_value: Default value for gates that are added back in. In case of
+        `None` that is also the default, the last known value is assumed
+    :param parameter_mask: Initialization values of paramater mask, defaults to `None`
+    :param layer_mask: Initialization values of layer mask, defaults to `None`
+    :param wire_mask: Initialization values of wire mask, defaults to `None`
     """
 
     __slots__ = (

--- a/maskit/masks.py
+++ b/maskit/masks.py
@@ -34,10 +34,17 @@ class Mask(object):
     __slots__ = ("mask", "_parent")
 
     def __init__(
-        self, shape: Tuple[int, ...], parent: Optional["MaskedCircuit"] = None
+        self,
+        shape: Tuple[int, ...],
+        parent: Optional["MaskedCircuit"] = None,
+        mask: Optional[np.ndarray] = None,
     ):
         super().__init__()
         self.mask = np.zeros(shape, dtype=bool, requires_grad=False)
+        if mask is not None:
+            assert mask.dtype == bool, "Mask must be of type bool"
+            assert mask.shape == shape, "Shape of mask must be equal to shape"
+            self.mask[:] = mask
         self._parent = parent
 
     def __len__(self) -> int:
@@ -188,6 +195,9 @@ class MaskedCircuit(object):
         layers: int,
         wires: int,
         default_value: Optional[float] = None,
+        parameter_mask: Optional[np.ndarray] = None,
+        layer_mask: Optional[np.ndarray] = None,
+        wire_mask: Optional[np.ndarray] = None,
     ):
         assert (
             layers == parameters.shape[0]
@@ -196,9 +206,11 @@ class MaskedCircuit(object):
             wires == parameters.shape[1]
         ), "Second dimension of parameters shape must be equal to number of wires"
         self.parameters = parameters
-        self._parameter_mask = Mask(shape=parameters.shape, parent=self)
-        self._layer_mask = Mask(shape=(layers,), parent=self)
-        self._wire_mask = Mask(shape=(wires,), parent=self)
+        self._parameter_mask = Mask(
+            shape=parameters.shape, parent=self, mask=parameter_mask
+        )
+        self._layer_mask = Mask(shape=(layers,), parent=self, mask=layer_mask)
+        self._wire_mask = Mask(shape=(wires,), parent=self, mask=wire_mask)
         self.default_value = default_value
 
     @property

--- a/tests/test_masks.py
+++ b/tests/test_masks.py
@@ -51,9 +51,9 @@ class TestMaskedCircuits:
             parameters=pnp.random.uniform(low=0, high=1, size=(size, size)),
             layers=size,
             wires=size,
-            wire_mask=pnp.array([True] * size),
+            wire_mask=pnp.ones((size,), dtype=bool),
         )
-        assert pnp.array_equal(mc.wire_mask, [True] * size)
+        assert pnp.array_equal(mc.wire_mask, pnp.ones((size,), dtype=bool))
 
     def test_wrong_mode(self):
         mp = self._create_circuit(3)

--- a/tests/test_masks.py
+++ b/tests/test_masks.py
@@ -47,6 +47,13 @@ class TestMaskedCircuits:
                 layers=size,
                 wires=size + 1,
             )
+        mc = MaskedCircuit(
+            parameters=pnp.random.uniform(low=0, high=1, size=(size, size)),
+            layers=size,
+            wires=size,
+            wire_mask=pnp.array([True] * size),
+        )
+        assert pnp.array_equal(mc.wire_mask, [True] * size)
 
     def test_wrong_mode(self):
         mp = self._create_circuit(3)
@@ -306,6 +313,16 @@ class TestFreezableMaskedCircuit:
 
 
 class TestMask:
+    def test_init(self):
+        size = 3
+        with pytest.raises(AssertionError):
+            Mask((size,), mask=pnp.array([True, True, False, False]))
+        with pytest.raises(AssertionError):
+            Mask((size,), mask=pnp.array([0, 1, 3]))
+        preset = [False, True, False]
+        mp = Mask((size,), mask=pnp.array(preset))
+        assert pnp.array_equal(mp.mask, preset)
+
     def test_setting(self):
         size = 3
         mp = Mask((size,))


### PR DESCRIPTION
This PR implements setting a preconfigured mask as discussed in #10.
Further, the exemplary code now uses this to realise the testing with learned mask.

Closes #10.