### PR TITLE
Cleanup of cross entropy calculation

### DIFF
--- a/maskit/utils.py
+++ b/maskit/utils.py
@@ -12,11 +12,12 @@ def cross_entropy(predictions, targets, epsilon=1e-12):
     """
     Computes cross entropy between targets (encoded as one-hot vectors)
     and predictions.
-    Input: predictions (N, k) ndarray
-           targets (N, k) ndarray
+    Input: predictions (N, k) or (k) ndarray
+           targets with the same dimensions as predictions
     Returns: scalar
     """
+    assert(predictions.shape == targets.shape)
     predictions = np.clip(predictions, epsilon, 1.0 - epsilon)
-    N = predictions.shape[0]
+    N = predictions.shape[0] if len(predictions.shape) == 2 else 1
     ce = -np.sum(targets * np.log(predictions + 1e-9)) / N
     return ce

--- a/maskit/utils.py
+++ b/maskit/utils.py
@@ -8,16 +8,38 @@ def check_params(train_params):
     assert isinstance(train_params["optimizer"], ExtendedOptimizers)
 
 
-def cross_entropy(predictions, targets, epsilon=1e-12):
+def cross_entropy(
+    predictions: np.ndarray, targets: np.ndarray, epsilon: float = 1e-15
+) -> float:
     """
-    Computes cross entropy between targets (encoded as one-hot vectors)
-    and predictions.
-    Input: predictions (N, k) or (k) ndarray
-           targets with the same dimensions as predictions
-    Returns: scalar
+    Cross entropy calculation between :py:attr:`targets` (encoded as one-hot vectors)
+    and :py:attr:`predictions`. Predictions are normalized to sum up to `1.0`.
+
+    .. note::
+
+        The implementation of this function is based on the discussion on
+        `StackOverflow <https://stackoverflow.com/a/47398312/10138546>`_.
+
+        Due to ArrayBoxes that are required for automatic differentiation, we currently
+        use this implementation instead of implementations provided by sklearn for
+        example.
+
+    :param predictions: Predictions in same order as targets. In case predictions for
+        several samples are given, the weighted cross entropy is returned.
+    :param targets: Ground truth labels for supplied samples.
+    :param epsilon: Amount to clip predictions as log is not defined for `0` and `1`.
     """
-    assert(predictions.shape == targets.shape)
+    assert (
+        predictions.shape == targets.shape
+    ), f"Shape of predictions {predictions.shape} must match targets {targets.shape}"
+    current_sum = np.sum(predictions, axis=predictions.ndim - 1)
+
+    if predictions.ndim == 1:
+        sample_count = 1
+        predictions = predictions / current_sum
+    else:
+        sample_count = predictions.shape[0]
+        predictions = predictions / current_sum[:, np.newaxis]
+
     predictions = np.clip(predictions, epsilon, 1.0 - epsilon)
-    N = predictions.shape[0] if len(predictions.shape) == 2 else 1
-    ce = -np.sum(targets * np.log(predictions + 1e-9)) / N
-    return ce
+    return -np.sum(targets * np.log(predictions)) / sample_count

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,5 +20,6 @@ test = [
     "flake8",
     "flake8-bugbear",
     "black",
+    "scikit-learn",
 ]
 dev = ["pre-commit"]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,30 @@
+import numpy as np
+import pytest
+from sklearn.metrics import log_loss
+
+from maskit.utils import cross_entropy
+
+
+@pytest.mark.parametrize(
+    "predictions,targets",
+    [
+        pytest.param(
+            np.array([[0.25, 0.25, 0.25, 0.25], [0.01, 0.01, 0.01, 0.96]]),
+            np.array([[0.0, 0.0, 0.0, 1.0], [0.0, 0.0, 0.0, 1.0]]),
+        ),
+        pytest.param(np.array([0.0, 0.0, 1.0, 0.0]), np.array([0.0, 0.0, 1.0, 0.0])),
+        pytest.param(
+            np.array([0.25, 0.25, 0.25, 0.25]), np.array([0.0, 0.0, 1.0, 0.0])
+        ),
+        pytest.param(
+            np.array([0.01, 0.01, 0.01, 0.96]), np.array([0.0, 0.0, 0.0, 1.0])
+        ),
+    ],
+)
+def test_cross_entropy(predictions, targets):
+    if predictions.ndim == 1:
+        expected_value = log_loss([targets], [predictions])
+    else:
+        expected_value = log_loss(targets, predictions)
+    calculated_value = cross_entropy(predictions=predictions, targets=targets)
+    assert np.isclose(expected_value, calculated_value)


### PR DESCRIPTION
Cross entropy calculation now weights results properly by number of samples. 
Further, the PR includes documentation, unit tests and normalisation of predictions.

Closes #47.