### PR TITLE
Convert pyproject.toml to new style metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
 ]
 requires-python = ">=3.7"
 dynamic = ["version", "description"]
-license = "LICENSE"
+license = {file = "LICENSE"}
 keywords = ["quantum computing",]
 dependencies = [
     "pennylane ~= 0.16.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,20 +1,27 @@
 [build-system]
-requires = ["flit_core >=2,<4"]
+requires = ["flit_core >=3.2,<4"]
 build-backend = "flit_core.buildapi"
 
-[tool.flit.metadata]
-module = "maskit"
-author = "Eileen Kuehn, Christof Wendenius"
-author-email = "eileen.kuehn@kit.edu"
-home-page = "https://github.com/cirKITers/masKIT"
-classifiers = [ "License :: OSI Approved :: MIT License",]
-description-file = "README.md"
-requires = [
+[project]
+name = "maskit"
+authors = [
+    {name = "Eileen Kuehn", email = "eileen.kuehn@kit.edu"},
+    {name = "Christof Wendenius", email = "christof.wendenius@kit.edu"},
+]
+readme = "README.md"
+classifiers = [
+    "License :: OSI Approved :: MIT License",
+]
+requires-python = ">=3.7"
+dynamic = ["version", "description"]
+license = "LICENSE"
+keywords = ["quantum computing",]
+dependencies = [
     "pennylane ~= 0.16.0",
     "typing_extensions",
 ]
 
-[tool.flit.metadata.requires-extra]
+[project.optional-dependencies]
 test = [
     "pytest >=4.3.0",
     "flake8",
@@ -22,3 +29,6 @@ test = [
     "black",
 ]
 dev = ["pre-commit"]
+
+[project.urls]
+Source = "https://github.com/cirKITers/masKIT"


### PR DESCRIPTION
This PR changes the style of pyproject.toml to new style metadata as described in [PEP621](https://www.python.org/dev/peps/pep-0621/). The latest version v1.0.0 of TOML standard is not supported yet but will be from flit_core >= 3.4.

Closes #41.