### PR TITLE
Rename PerturbationAxis.RANDOM to PARAMETERS

### DIFF
--- a/main.py
+++ b/main.py
@@ -272,7 +272,7 @@ if __name__ == "__main__":
                         "perturb": {
                             "amount": 1,
                             "mode": PerturbationMode.ADD,
-                            "axis": PerturbationAxis.RANDOM,
+                            "axis": PerturbationAxis.PARAMETERS,
                         },
                     },
                 ],
@@ -282,7 +282,7 @@ if __name__ == "__main__":
                         "perturb": {
                             "amount": 0.05,
                             "mode": PerturbationMode.REMOVE,
-                            "axis": PerturbationAxis.RANDOM,
+                            "axis": PerturbationAxis.PARAMETERS,
                         }
                     },
                 ],

--- a/maskit/masks.py
+++ b/maskit/masks.py
@@ -12,7 +12,7 @@ class PerturbationAxis(Enum):
     #: Perturbation affects whole layers
     LAYERS = 1
     #: Perturbation affects random locations in parameter mask
-    RANDOM = 2
+    PARAMETERS = 2
     #: Perturbation affects entangling gates
     ENTANGLING = 3
 
@@ -304,7 +304,7 @@ class MaskedCircuit(object):
 
     def perturb(
         self,
-        axis: PerturbationAxis = PerturbationAxis.RANDOM,
+        axis: PerturbationAxis = PerturbationAxis.PARAMETERS,
         amount: Optional[Union[int, float]] = None,
         mode: PerturbationMode = PerturbationMode.INVERT,
     ):
@@ -330,7 +330,7 @@ class MaskedCircuit(object):
             self._layer_mask.perturb(amount=amount, mode=mode)
         elif axis == PerturbationAxis.WIRES:
             self._wire_mask.perturb(amount=amount, mode=mode)
-        elif axis == PerturbationAxis.RANDOM:  # Axis is on parameters
+        elif axis == PerturbationAxis.PARAMETERS:  # Axis is on parameters
             self._parameter_mask.perturb(amount=amount, mode=mode)
         elif axis == PerturbationAxis.ENTANGLING:
             if self._entangling_mask:
@@ -343,7 +343,7 @@ class MaskedCircuit(object):
             self._layer_mask.shrink(amount)
         elif axis == PerturbationAxis.WIRES:
             self._wire_mask.shrink(amount)
-        elif axis == PerturbationAxis.RANDOM:
+        elif axis == PerturbationAxis.PARAMETERS:
             self._parameter_mask.shrink(amount)
         elif axis == PerturbationAxis.ENTANGLING:
             if self._entangling_mask:
@@ -577,7 +577,7 @@ class FreezableMaskedCircuit(MaskedCircuit):
             self._layer_freeze_mask.perturb(amount=amount, mode=mode)
         elif axis == PerturbationAxis.WIRES:
             self._wire_freeze_mask.perturb(amount=amount, mode=mode)
-        elif axis == PerturbationAxis.RANDOM:  # Axis is on parameters
+        elif axis == PerturbationAxis.PARAMETERS:  # Axis is on parameters
             self._parameter_freeze_mask.perturb(amount=amount, mode=mode)
         else:
             raise NotImplementedError(f"The perturbation {axis} is not supported")

--- a/tests/configurations.py
+++ b/tests/configurations.py
@@ -8,7 +8,7 @@ CLASSICAL = {
             "perturb": {
                 "amount": 0.1,
                 "mode": PerturbationMode.ADD,
-                "axis": PerturbationAxis.RANDOM,
+                "axis": PerturbationAxis.PARAMETERS,
             }
         },
     ],
@@ -24,7 +24,7 @@ RANDOM = {
             "perturb": {
                 "amount": 1,
                 "mode": PerturbationMode.REMOVE,
-                "axis": PerturbationAxis.RANDOM,
+                "axis": PerturbationAxis.PARAMETERS,
             }
         },
     ],
@@ -34,7 +34,7 @@ RANDOM = {
             "perturb": {
                 "amount": None,
                 "mode": PerturbationMode.INVERT,
-                "axis": PerturbationAxis.RANDOM,
+                "axis": PerturbationAxis.PARAMETERS,
             }
         },
     ],
@@ -48,7 +48,7 @@ QHACK = {
             "perturb": {
                 "amount": 1,
                 "mode": PerturbationMode.ADD,
-                "axis": PerturbationAxis.RANDOM,
+                "axis": PerturbationAxis.PARAMETERS,
             },
         },
     ],
@@ -58,7 +58,7 @@ QHACK = {
             "perturb": {
                 "amount": 0.05,
                 "mode": PerturbationMode.REMOVE,
-                "axis": PerturbationAxis.RANDOM,
+                "axis": PerturbationAxis.PARAMETERS,
             }
         },
     ],

--- a/tests/test_masks.py
+++ b/tests/test_masks.py
@@ -193,7 +193,7 @@ class TestMaskedCircuits:
         size = 3
         mp = self._create_circuit(size)
         mp.parameter_mask[:] = True
-        mp.shrink(amount=1, axis=PerturbationAxis.RANDOM)
+        mp.shrink(amount=1, axis=PerturbationAxis.PARAMETERS)
         assert pnp.sum(mp.mask) == mp.mask.size - 1
 
     def test_shrink_entangling(self):
@@ -219,7 +219,7 @@ class TestMaskedCircuits:
         perturb_operation = {
             "perturb": {
                 "amount": 1,
-                "axis": PerturbationAxis.RANDOM,
+                "axis": PerturbationAxis.PARAMETERS,
                 "mode": PerturbationMode.ADD,
             }
         }
@@ -274,7 +274,7 @@ class TestMaskedCircuits:
         )
         mp.parameter_mask[:] = True
         mp.perturb(
-            axis=PerturbationAxis.RANDOM, amount=0.5, mode=PerturbationMode.INVERT
+            axis=PerturbationAxis.PARAMETERS, amount=0.5, mode=PerturbationMode.INVERT
         )
         assert pnp.sum(mp.parameters == 0) == round(0.5 * 4 * 3 * 2)
 
@@ -365,7 +365,7 @@ class TestFreezableMaskedCircuit:
         assert pnp.sum(mp.wire_freeze_mask) == 1
         assert pnp.sum(mp.mask) == 2 * size - 1
         # Test freezing of parameters
-        mp.freeze(axis=PerturbationAxis.RANDOM, amount=1, mode=PerturbationMode.ADD)
+        mp.freeze(axis=PerturbationAxis.PARAMETERS, amount=1, mode=PerturbationMode.ADD)
         assert pnp.sum(mp.parameter_freeze_mask) == 1
         assert pnp.sum(mp.mask) == 2 * size - 1 or pnp.sum(mp.mask) == 2 * size
         # Test wrong axis


### PR DESCRIPTION
As discussed in #43 the current naming of `PerturbationAxis` was a bit confusion. This is fixed now by renaming `RANDOM` to `PARAMETERS`. This axis only interacts on parameters and not randomly between wires, layers etc.

Closes #43.