### PR TITLE
Add mask to perturb parameters for specific values

### DIFF
--- a/main.py
+++ b/main.py
@@ -173,7 +173,9 @@ def train(
             logging_branch_cost_step["brutto"][step] = result.brutto_steps
             logging_branch_cost_step["netto"][step] = result.netto_steps
         logging_cost_values.append(result.cost)
-        logging_dropout_count_values.append(np.sum(masked_circuit.mask))
+        logging_dropout_count_values.append(
+            np.sum(masked_circuit.mask_for_type(DropoutMask))
+        )
         if step % train_params["log_interval"] == 0:
             # perform logging
             logging_costs[step] = np.average(logging_cost_values)
@@ -189,7 +191,7 @@ def train(
 
     if __debug__:
         print(masked_circuit.parameters)
-        print(masked_circuit.mask)
+        print(masked_circuit.mask_for_type(DropoutMask))
 
     return {
         "costs": logging_costs,
@@ -200,7 +202,7 @@ def train(
         "branch_step_costs": logging_branch_cost_step,
         "final_layers": current_layers,
         "params": masked_circuit.parameters.unwrap(),
-        "mask": masked_circuit.mask.unwrap(),
+        "dropout_mask": masked_circuit.mask_for_type(DropoutMask).unwrap(),
         "__wire_mask": masked_circuit.mask_for_axis(Axis.WIRES).mask,
         "__layer_mask": masked_circuit.mask_for_axis(Axis.LAYERS).mask,
         "__parameter_mask": masked_circuit.mask_for_axis(Axis.PARAMETERS).mask,

--- a/main.py
+++ b/main.py
@@ -73,7 +73,7 @@ def init_parameters(
         entangling_mask=DropoutMask(shape=(layers, wires - 1)),
         dynamic_parameters=dynamic_parameters,
     )
-    mc.mask_for_axis(Axis.LAYERS)[current_layers:] = True
+    mc.mask(Axis.LAYERS)[current_layers:] = True
     return mc
 
 
@@ -203,9 +203,9 @@ def train(
         "final_layers": current_layers,
         "params": masked_circuit.parameters.unwrap(),
         "dropout_mask": masked_circuit.full_mask(DropoutMask).unwrap(),
-        "__wire_mask": masked_circuit.mask_for_axis(Axis.WIRES).mask,
-        "__layer_mask": masked_circuit.mask_for_axis(Axis.LAYERS).mask,
-        "__parameter_mask": masked_circuit.mask_for_axis(Axis.PARAMETERS).mask,
+        "__wire_mask": masked_circuit.mask(Axis.WIRES).mask,
+        "__layer_mask": masked_circuit.mask(Axis.LAYERS).mask,
+        "__parameter_mask": masked_circuit.mask(Axis.PARAMETERS).mask,
         "__rotations": rotations,
     }
 

--- a/main.py
+++ b/main.py
@@ -5,7 +5,7 @@ import pennylane as qml
 from pennylane import numpy as np
 
 from maskit._masks import (
-    Mask,
+    DropoutMask,
     PerturbationAxis as Axis,
     PerturbationMode as Mode,
 )
@@ -70,7 +70,7 @@ def init_parameters(
         layers=layers,
         wires=wires,
         default_value=default_value,
-        entangling_mask=Mask(shape=(layers, wires - 1)),
+        entangling_mask=DropoutMask(shape=(layers, wires - 1)),
         dynamic_parameters=dynamic_parameters,
     )
     mc.mask_for_axis(Axis.LAYERS)[current_layers:] = True

--- a/main.py
+++ b/main.py
@@ -291,7 +291,7 @@ if __name__ == "__main__":
                     {
                         "perturb": {
                             "amount": 1,
-                            "mode": Mode.ADD,
+                            "mode": Mode.SET,
                             "axis": Axis.PARAMETERS,
                         },
                     },
@@ -301,7 +301,7 @@ if __name__ == "__main__":
                     {
                         "perturb": {
                             "amount": 0.05,
-                            "mode": Mode.REMOVE,
+                            "mode": Mode.RESET,
                             "axis": Axis.PARAMETERS,
                         }
                     },

--- a/main.py
+++ b/main.py
@@ -174,7 +174,7 @@ def train(
             logging_branch_cost_step["netto"][step] = result.netto_steps
         logging_cost_values.append(result.cost)
         logging_dropout_count_values.append(
-            np.sum(masked_circuit.mask_for_type(DropoutMask))
+            np.sum(masked_circuit.full_mask(DropoutMask))
         )
         if step % train_params["log_interval"] == 0:
             # perform logging
@@ -191,7 +191,7 @@ def train(
 
     if __debug__:
         print(masked_circuit.parameters)
-        print(masked_circuit.mask_for_type(DropoutMask))
+        print(masked_circuit.full_mask(DropoutMask))
 
     return {
         "costs": logging_costs,
@@ -202,7 +202,7 @@ def train(
         "branch_step_costs": logging_branch_cost_step,
         "final_layers": current_layers,
         "params": masked_circuit.parameters.unwrap(),
-        "dropout_mask": masked_circuit.mask_for_type(DropoutMask).unwrap(),
+        "dropout_mask": masked_circuit.full_mask(DropoutMask).unwrap(),
         "__wire_mask": masked_circuit.mask_for_axis(Axis.WIRES).mask,
         "__layer_mask": masked_circuit.mask_for_axis(Axis.LAYERS).mask,
         "__parameter_mask": masked_circuit.mask_for_axis(Axis.PARAMETERS).mask,

--- a/maskit/_masked_circuits.py
+++ b/maskit/_masked_circuits.py
@@ -188,10 +188,12 @@ class MaskedCircuit(object):
         ), f"The selected perturbation mode {mode} is not supported."
         if amount == 0:
             return
-        if axis in self.masks and mask in self.masks[axis]:
+        try:
             self.masks[axis][mask].perturb(amount=amount, mode=mode)
-        else:
-            raise ValueError(f"The mask {mask} on axis {axis} is not supported")
+        except KeyError:
+            raise ValueError(
+                f"The mask {mask} on axis {axis} is not supported"
+            ) from None
 
     def shrink(
         self, axis: Axis = Axis.LAYERS, amount: int = 1, mask: Type[Mask] = DropoutMask

--- a/maskit/_masked_circuits.py
+++ b/maskit/_masked_circuits.py
@@ -87,7 +87,7 @@ class MaskedCircuit(object):
         except KeyError:
             self.masks[axis] = {type(mask): mask}
 
-    def mask_for_axis(self, axis: Axis, mask_type: Type[Mask] = DropoutMask) -> Mask:
+    def mask(self, axis: Axis, mask_type: Type[Mask] = DropoutMask) -> Mask:
         return self.masks[axis][mask_type]
 
     def _accumulated_mask(self, for_differentiable=True) -> np.ndarray:
@@ -292,7 +292,7 @@ class MaskedCircuit(object):
         length = 0
         first_layer = True
         result = ["["]
-        for layer, layer_hidden in enumerate(self.mask_for_axis(Axis.LAYERS)):
+        for layer, layer_hidden in enumerate(self.mask(Axis.LAYERS)):
             if first_layer:
                 result.append("[")
                 first_layer = False
@@ -300,9 +300,9 @@ class MaskedCircuit(object):
                 result.append("\n [")
             first_wire = True
             first_value = True
-            for wire, wire_hidden in enumerate(self.mask_for_axis(Axis.WIRES)):
+            for wire, wire_hidden in enumerate(self.mask(Axis.WIRES)):
                 if isinstance(
-                    self.mask_for_axis(Axis.PARAMETERS)[layer][wire].unwrap(),
+                    self.mask(Axis.PARAMETERS)[layer][wire].unwrap(),
                     np.ndarray,
                 ):
                     if first_wire:
@@ -312,7 +312,7 @@ class MaskedCircuit(object):
                         result.append("\n  [")
                     first_value = True
                     for parameter, parameter_hidden in enumerate(
-                        self.mask_for_axis(Axis.PARAMETERS)[layer][wire]
+                        self.mask(Axis.PARAMETERS)[layer][wire]
                     ):
                         if not (layer_hidden or wire_hidden or parameter_hidden):
                             value = format_value(
@@ -331,7 +331,7 @@ class MaskedCircuit(object):
                     if not (
                         layer_hidden
                         or wire_hidden
-                        or self.mask_for_axis(Axis.PARAMETERS)[layer][wire]
+                        or self.mask(Axis.PARAMETERS)[layer][wire]
                     ):
                         value = format_value(self.parameters[layer][wire])
                         length = len(value)
@@ -392,5 +392,5 @@ if __name__ == "__main__":
     parameter = MaskedCircuit(
         np.array(([21, 22, 23], [11, 22, 33], [43, 77, 89])), 3, 3
     )
-    parameter.mask_for_axis(Axis.WIRES)[1] = True
+    parameter.mask(Axis.WIRES)[1] = True
     print(parameter)

--- a/maskit/_masked_circuits.py
+++ b/maskit/_masked_circuits.py
@@ -1,7 +1,12 @@
 import pennylane.numpy as np
 
 from typing import Dict, Iterable, List, Optional, Tuple, Type, TypeVar, Union
-from maskit._masks import Mask, PerturbationAxis as Axis, PerturbationMode as Mode
+from maskit._masks import (
+    Mask,
+    DropoutMask,
+    PerturbationAxis as Axis,
+    PerturbationMode as Mode,
+)
 
 Self = TypeVar("Self")
 
@@ -322,7 +327,7 @@ class MaskedCircuit(object):
             parameters=parameters,
             layers=layers,
             wires=wires,
-            masks=[(axis, Mask) for axis in initializable_masks],
+            masks=[(axis, DropoutMask) for axis in initializable_masks],
             dynamic_parameters=dynamic_parameters,
             default_value=default_value,
         )
@@ -462,8 +467,10 @@ class FreezableMaskedCircuit(MaskedCircuit):
             parameters=parameters,
             layers=layers,
             wires=wires,
-            masks=[(axis, Mask) for axis in initializable_masks],
-            freeze_masks=[(axis, Mask) for axis in Axis if axis != Axis.ENTANGLING],
+            masks=[(axis, DropoutMask) for axis in initializable_masks],
+            freeze_masks=[
+                (axis, DropoutMask) for axis in Axis if axis != Axis.ENTANGLING
+            ],
             dynamic_parameters=dynamic_parameters,
             default_value=default_value,
         )

--- a/maskit/_masked_circuits.py
+++ b/maskit/_masked_circuits.py
@@ -404,7 +404,7 @@ class FreezableMaskedCircuit(MaskedCircuit):
         self,
         axis: Axis = Axis.LAYERS,
         amount: Optional[Union[int, float]] = None,
-        mode: Mode = Mode.ADD,
+        mode: Mode = Mode.SET,
     ):
         """
         Freezes the parameter values for a given ``axis`` that is of type

--- a/maskit/_masks.py
+++ b/maskit/_masks.py
@@ -42,7 +42,17 @@ class Mask(Protocol[T]):
     :param mask: Preset of values that is taken by mask
     """
 
+    relevant_for_differentiation: bool = False
     __slots__ = ("mask", "_parent")
+
+    @abstractmethod
+    def __init__(
+        self,
+        shape: Tuple[int, ...],
+        parent: Optional["MaskedCircuit"] = None,
+        mask: Optional[np.ndarray] = None,
+    ):
+        pass
 
     def __len__(self) -> int:
         """Returns the len of the encapsulated :py:attr:`~.mask`"""
@@ -156,6 +166,8 @@ class Mask(Protocol[T]):
 
 
 class DropoutMask(Mask[bool]):
+    relevant_for_differentiation = True
+
     def __init__(
         self,
         shape: Tuple[int, ...],
@@ -211,7 +223,19 @@ class DropoutMask(Mask[bool]):
             self[tuple(zip(*index))] = False
 
 
+class FreezeMask(DropoutMask):
+    """
+    A FreezeMask provides the same functionality as a :py:class:`~.DropoutMask`.
+    However, the meaning is a bit different. Marked positions are interpreted as
+    being frozen and underlying values therefore cannot be changed.
+    """
+
+    pass
+
+
 class ValueMask(Mask[float]):
+    relevant_for_differentiation = False
+
     def __init__(
         self,
         shape: Tuple[int, ...],

--- a/maskit/_masks.py
+++ b/maskit/_masks.py
@@ -19,10 +19,10 @@ class PerturbationAxis(Enum):
 
 
 class PerturbationMode(Enum):
-    #: Adding new holes to the mask
-    ADD = 0
-    #: Removing holes from the mask
-    REMOVE = 1
+    #: Set a new value on a mask
+    SET = 0
+    #: Remove a value from the mask
+    RESET = 1
     #: Invert current state of the mask
     INVERT = 2
 
@@ -147,11 +147,11 @@ class Mask(object):
         count = abs(amount) if amount is not None else rand.randrange(0, self.mask.size)
         if count == 0:
             return
-        if mode == PerturbationMode.ADD:
+        if mode == PerturbationMode.SET:
             indices = np.argwhere(~self.mask)
         elif mode == PerturbationMode.INVERT:
             indices = np.array([list(index) for index in np.ndindex(*self.mask.shape)])
-        elif mode == PerturbationMode.REMOVE:
+        elif mode == PerturbationMode.RESET:
             indices = np.argwhere(self.mask)
         else:
             raise NotImplementedError(f"The perturbation mode {mode} is not supported")

--- a/maskit/_masks.py
+++ b/maskit/_masks.py
@@ -2,7 +2,8 @@ import random as rand
 import pennylane.numpy as np
 from abc import abstractmethod
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Optional, Protocol, Tuple, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Optional, Tuple, TypeVar, Union
+from typing_extensions import Protocol
 
 if TYPE_CHECKING:
     from maskit._masked_circuits import MaskedCircuit

--- a/maskit/circuits.py
+++ b/maskit/circuits.py
@@ -6,15 +6,13 @@ from pennylane import numpy as np
 
 def basic_variational_circuit(params, rotations, masked_circuit: MaskedCircuit):
     full_parameters = masked_circuit.expanded_parameters(params)
-    wires = len(masked_circuit.mask_for_axis(Axis.WIRES))
+    wires = len(masked_circuit.mask(Axis.WIRES))
     dropout_mask = masked_circuit.full_mask(DropoutMask)
-    for wire, _is_masked in enumerate(masked_circuit.mask_for_axis(Axis.WIRES)):
+    for wire, _is_masked in enumerate(masked_circuit.mask(Axis.WIRES)):
         qml.RY(np.pi / 4, wires=wire)
     r = -1
-    for layer, _is_layer_masked in enumerate(masked_circuit.mask_for_axis(Axis.LAYERS)):
-        for wire, _is_wire_masked in enumerate(
-            masked_circuit.mask_for_axis(Axis.WIRES)
-        ):
+    for layer, _is_layer_masked in enumerate(masked_circuit.mask(Axis.LAYERS)):
+        for wire, _is_wire_masked in enumerate(masked_circuit.mask(Axis.WIRES)):
             r += 1
             if dropout_mask[layer][wire]:
                 continue
@@ -28,15 +26,15 @@ def basic_variational_circuit(params, rotations, masked_circuit: MaskedCircuit):
 
         for wire in range(0, wires - 1, 2):
             if (
-                masked_circuit.mask_for_axis(Axis.ENTANGLING) is not None
-                and masked_circuit.mask_for_axis(Axis.ENTANGLING)[layer, wire]
+                masked_circuit.mask(Axis.ENTANGLING) is not None
+                and masked_circuit.mask(Axis.ENTANGLING)[layer, wire]
             ):
                 continue
             qml.CZ(wires=[wire, wire + 1])
         for wire in range(1, wires - 1, 2):
             if (
-                masked_circuit.mask_for_axis(Axis.ENTANGLING) is not None
-                and masked_circuit.mask_for_axis(Axis.ENTANGLING)[layer, wire]
+                masked_circuit.mask(Axis.ENTANGLING) is not None
+                and masked_circuit.mask(Axis.ENTANGLING)[layer, wire]
             ):
                 continue
             qml.CZ(wires=[wire, wire + 1])
@@ -49,7 +47,9 @@ def variational_circuit(params, rotations, masked_circuit):
         rotations=rotations,
         masked_circuit=masked_circuit,
     )
-    return qml.probs(wires=range(len(masked_circuit.mask_for_axis(Axis.WIRES))))
+    return qml.probs(
+        wires=range(len(masked_circuit.mask(axis=Axis.WIRES, mask_type=DropoutMask)))
+    )
 
 
 def iris_circuit(params, data, rotations, masked_circuit):

--- a/maskit/circuits.py
+++ b/maskit/circuits.py
@@ -1,4 +1,4 @@
-from maskit._masks import PerturbationAxis as Axis
+from maskit._masks import PerturbationAxis as Axis, DropoutMask
 from maskit._masked_circuits import MaskedCircuit
 import pennylane as qml
 from pennylane import numpy as np
@@ -7,7 +7,7 @@ from pennylane import numpy as np
 def basic_variational_circuit(params, rotations, masked_circuit: MaskedCircuit):
     full_parameters = masked_circuit.expanded_parameters(params)
     wires = len(masked_circuit.mask_for_axis(Axis.WIRES))
-    mask = masked_circuit.mask
+    dropout_mask = masked_circuit.mask_for_type(DropoutMask)
     for wire, _is_masked in enumerate(masked_circuit.mask_for_axis(Axis.WIRES)):
         qml.RY(np.pi / 4, wires=wire)
     r = -1
@@ -16,7 +16,7 @@ def basic_variational_circuit(params, rotations, masked_circuit: MaskedCircuit):
             masked_circuit.mask_for_axis(Axis.WIRES)
         ):
             r += 1
-            if mask[layer][wire]:
+            if dropout_mask[layer][wire]:
                 continue
             if rotations[r] == 0:
                 rotation = qml.RX

--- a/maskit/circuits.py
+++ b/maskit/circuits.py
@@ -7,7 +7,7 @@ from pennylane import numpy as np
 def basic_variational_circuit(params, rotations, masked_circuit: MaskedCircuit):
     full_parameters = masked_circuit.expanded_parameters(params)
     wires = len(masked_circuit.mask_for_axis(Axis.WIRES))
-    dropout_mask = masked_circuit.mask_for_type(DropoutMask)
+    dropout_mask = masked_circuit.full_mask(DropoutMask)
     for wire, _is_masked in enumerate(masked_circuit.mask_for_axis(Axis.WIRES)):
         qml.RY(np.pi / 4, wires=wire)
     r = -1

--- a/tests/configurations.py
+++ b/tests/configurations.py
@@ -7,7 +7,7 @@ CLASSICAL = {
         {
             "perturb": {
                 "amount": 0.1,
-                "mode": PerturbationMode.ADD,
+                "mode": PerturbationMode.SET,
                 "axis": PerturbationAxis.PARAMETERS,
             }
         },
@@ -23,7 +23,7 @@ RANDOM = {
         {
             "perturb": {
                 "amount": 1,
-                "mode": PerturbationMode.REMOVE,
+                "mode": PerturbationMode.RESET,
                 "axis": PerturbationAxis.PARAMETERS,
             }
         },
@@ -47,7 +47,7 @@ QHACK = {
         {
             "perturb": {
                 "amount": 1,
-                "mode": PerturbationMode.ADD,
+                "mode": PerturbationMode.SET,
                 "axis": PerturbationAxis.PARAMETERS,
             },
         },
@@ -57,7 +57,7 @@ QHACK = {
         {
             "perturb": {
                 "amount": 0.05,
-                "mode": PerturbationMode.REMOVE,
+                "mode": PerturbationMode.RESET,
                 "axis": PerturbationAxis.PARAMETERS,
             }
         },

--- a/tests/test_ensembles.py
+++ b/tests/test_ensembles.py
@@ -35,9 +35,7 @@ class TestEnsemble:
     def test_ensemble_step(self, dropout):
         mp = create_circuit(3, layer_size=2)
         optimizer = ExtendedGradientDescentOptimizer()
-        circuit = qml.QNode(
-            variational_circuit, device(mp.mask_for_axis(Axis.WIRES).size)
-        )
+        circuit = qml.QNode(variational_circuit, device(mp.mask(Axis.WIRES).size))
         ensemble = Ensemble(dropout=dropout)
 
         def cost_fn(params, masked_circuit=None):
@@ -74,9 +72,7 @@ class TestIntervalEnsemble:
         interval = 3
         mp = create_circuit(3, layer_size=2)
         optimizer = ExtendedGradientDescentOptimizer()
-        circuit = qml.QNode(
-            variational_circuit, device(mp.mask_for_axis(Axis.WIRES).size)
-        )
+        circuit = qml.QNode(variational_circuit, device(mp.mask(Axis.WIRES).size))
         simple_ensemble = Ensemble(dropout=None)
         interval_ensemble = IntervalEnsemble(dropout=dropout, interval=interval)
 
@@ -124,9 +120,7 @@ class TestAdaptiveEnsemble:
         pnp.random.seed(1234)
         mp = create_circuit(3, layer_size=2)
         optimizer = ExtendedGradientDescentOptimizer()
-        circuit = qml.QNode(
-            variational_circuit, device(mp.mask_for_axis(Axis.WIRES).size)
-        )
+        circuit = qml.QNode(variational_circuit, device(mp.mask(Axis.WIRES).size))
         simple_ensemble = Ensemble(dropout=None)
         adaptive_ensemble = AdaptiveEnsemble(dropout=dropout, size=3, epsilon=0.01)
 
@@ -166,9 +160,7 @@ class TestEnsembleUseCases:
         pnp.random.seed(1234)
         mp = create_circuit(3, layer_size=2)
         ensemble = Ensemble(dropout=CLASSICAL)
-        circuit = qml.QNode(
-            variational_circuit, device(mp.mask_for_axis(Axis.WIRES).size)
-        )
+        circuit = qml.QNode(variational_circuit, device(mp.mask(Axis.WIRES).size))
         optimizer = ExtendedGradientDescentOptimizer()
 
         def cost_fn(params, masked_circuit=None):
@@ -189,11 +181,9 @@ class TestEnsembleUseCases:
         random.seed(1234)
         pnp.random.seed(1234)
         mp = create_circuit(3, layer_size=2)
-        mp.mask_for_axis(Axis.LAYERS)[1:] = True
+        mp.mask(Axis.LAYERS)[1:] = True
         ensemble = Ensemble(dropout=GROWING)
-        circuit = qml.QNode(
-            variational_circuit, device(mp.mask_for_axis(Axis.WIRES).size)
-        )
+        circuit = qml.QNode(variational_circuit, device(mp.mask(Axis.WIRES).size))
         optimizer = ExtendedGradientDescentOptimizer()
 
         def cost_fn(params, masked_circuit=None):
@@ -204,22 +194,20 @@ class TestEnsembleUseCases:
             )
 
         current_cost = 1.0
-        assert pnp.sum(mp.mask_for_axis(Axis.LAYERS)) == 2
-        for _ in range(len(mp.mask_for_axis(Axis.LAYERS)) - 1):
+        assert pnp.sum(mp.mask(Axis.LAYERS)) == 2
+        for _ in range(len(mp.mask(Axis.LAYERS)) - 1):
             result = ensemble.step(mp, optimizer, cost_fn)
             mp = result.branch
             current_cost = result.cost
         assert current_cost == pytest.approx(0.86318044)
-        assert pnp.sum(mp.mask_for_axis(Axis.LAYERS)) == 0
+        assert pnp.sum(mp.mask(Axis.LAYERS)) == 0
 
     def test_random(self):
         random.seed(1234)
         pnp.random.seed(1234)
         mp = create_circuit(3, layer_size=2)
         ensemble = Ensemble(dropout=RANDOM)
-        circuit = qml.QNode(
-            variational_circuit, device(mp.mask_for_axis(Axis.WIRES).size)
-        )
+        circuit = qml.QNode(variational_circuit, device(mp.mask(Axis.WIRES).size))
         optimizer = ExtendedGradientDescentOptimizer()
 
         def cost_fn(params, masked_circuit=None):
@@ -241,9 +229,7 @@ class TestEnsembleUseCases:
         pnp.random.seed(1234)
         mp = create_circuit(3, layer_size=2)
         ensemble = Ensemble(dropout=QHACK)
-        circuit = qml.QNode(
-            variational_circuit, device(mp.mask_for_axis(Axis.WIRES).size)
-        )
+        circuit = qml.QNode(variational_circuit, device(mp.mask(Axis.WIRES).size))
         optimizer = ExtendedGradientDescentOptimizer()
 
         def cost_fn(params, masked_circuit=None):

--- a/tests/test_masked_circuits.py
+++ b/tests/test_masked_circuits.py
@@ -267,7 +267,7 @@ class TestMaskedCircuits:
             "perturb": {
                 "amount": 1,
                 "axis": Axis.PARAMETERS,
-                "mode": Mode.ADD,
+                "mode": Mode.SET,
             }
         }
         # test empty operations
@@ -370,7 +370,7 @@ class TestMaskedCircuits:
         circuit(mp.differentiable_parameters, rotations, mp)
         assert circuit.specs["gate_types"]["CZ"] == 12
 
-        mp.perturb(axis=Axis.ENTANGLING, mode=Mode.ADD, amount=6)
+        mp.perturb(axis=Axis.ENTANGLING, mode=Mode.SET, amount=6)
         circuit(mp.differentiable_parameters, rotations, mp)
         assert circuit.specs["gate_types"]["CZ"] == 6
 
@@ -429,10 +429,10 @@ class TestFreezableMaskedCircuit:
         )
         # Test 0 amount
         mask = mp.mask
-        mp.freeze(axis=Axis.LAYERS, amount=0, mode=Mode.ADD)
+        mp.freeze(axis=Axis.LAYERS, amount=0, mode=Mode.SET)
         assert pnp.array_equal(mp.mask, mask)
         # Test freezing of layers
-        mp.freeze(axis=Axis.LAYERS, amount=1, mode=Mode.ADD)
+        mp.freeze(axis=Axis.LAYERS, amount=1, mode=Mode.SET)
         assert (
             mp.differentiable_parameters.size
             == mp.mask_for_axis(Axis.PARAMETERS).size - size
@@ -440,26 +440,26 @@ class TestFreezableMaskedCircuit:
         assert pnp.sum(mp.freeze_mask_for_axis(Axis.LAYERS)) == 1
         assert pnp.sum(mp.mask) == size
         # Test freezing of wires
-        mp.freeze(axis=Axis.WIRES, amount=1, mode=Mode.ADD)
+        mp.freeze(axis=Axis.WIRES, amount=1, mode=Mode.SET)
         assert pnp.sum(mp.freeze_mask_for_axis(Axis.WIRES)) == 1
         assert pnp.sum(mp.mask) == 2 * size - 1
         # Test freezing of parameters
-        mp.freeze(axis=Axis.PARAMETERS, amount=1, mode=Mode.ADD)
+        mp.freeze(axis=Axis.PARAMETERS, amount=1, mode=Mode.SET)
         assert pnp.sum(mp.freeze_mask_for_axis(Axis.PARAMETERS)) == 1
         assert pnp.sum(mp.mask) == 2 * size - 1 or pnp.sum(mp.mask) == 2 * size
         # Test wrong axis
         with pytest.raises(NotImplementedError):
-            mp.freeze(axis=10, amount=1, mode=Mode.ADD)
+            mp.freeze(axis=10, amount=1, mode=Mode.SET)
 
     def test_copy(self):
         mp = create_freezable_circuit(3)
-        mp.perturb(amount=5, mode=Mode.ADD)
-        mp.freeze(amount=2, axis=Axis.LAYERS, mode=Mode.ADD)
+        mp.perturb(amount=5, mode=Mode.SET)
+        mp.freeze(amount=2, axis=Axis.LAYERS, mode=Mode.SET)
         mp_copy = mp.copy()
         assert isinstance(mp_copy, FreezableMaskedCircuit)
         assert pnp.array_equal(mp.mask, mp_copy.mask)
-        mp.perturb(amount=5, mode=Mode.REMOVE)
-        mp.freeze(amount=2, axis=Axis.LAYERS, mode=Mode.REMOVE)
+        mp.perturb(amount=5, mode=Mode.RESET)
+        mp.freeze(amount=2, axis=Axis.LAYERS, mode=Mode.RESET)
         assert pnp.sum(mp.mask) == 0
         assert not pnp.array_equal(mp.mask, mp_copy.mask)
 
@@ -479,8 +479,8 @@ class TestFreezableMaskedCircuit:
                 masked_circuit,
             )
 
-        mp.freeze(axis=Axis.LAYERS, amount=2, mode=Mode.ADD)
-        mp.freeze(axis=Axis.WIRES, amount=2, mode=Mode.ADD)
+        mp.freeze(axis=Axis.LAYERS, amount=2, mode=Mode.SET)
+        mp.freeze(axis=Axis.WIRES, amount=2, mode=Mode.SET)
 
         last_changeable = pnp.sum(mp.parameters[~mp.mask])
         frozen = pnp.sum(mp.parameters[mp.mask])

--- a/tests/test_masked_circuits.py
+++ b/tests/test_masked_circuits.py
@@ -5,7 +5,11 @@ import pennylane as qml
 import pennylane.numpy as pnp
 
 from maskit.circuits import variational_circuit as original_variational_circuit
-from maskit._masks import PerturbationAxis as Axis, PerturbationMode as Mode, Mask
+from maskit._masks import (
+    PerturbationAxis as Axis,
+    PerturbationMode as Mode,
+    DropoutMask,
+)
 from maskit._masked_circuits import FreezableMaskedCircuit, MaskedCircuit
 
 from tests.utils import cost, create_freezable_circuit, device, variational_circuit
@@ -49,14 +53,14 @@ class TestMaskedCircuits:
                 parameters=pnp.random.uniform(low=0, high=1, size=(size, size)),
                 layers=size,
                 wires=size,
-                entangling_mask=Mask(shape=(size + 1, size)),
+                entangling_mask=DropoutMask(shape=(size + 1, size)),
             )
         with pytest.raises(NotImplementedError):
             MaskedCircuit(
                 parameters=pnp.random.uniform(low=0, high=1, size=(size, size)),
                 layers=size,
                 wires=size,
-                masks=[(Axis.ENTANGLING, Mask)],
+                masks=[(Axis.ENTANGLING, DropoutMask)],
             )
         mc = MaskedCircuit.full_circuit(
             parameters=pnp.random.uniform(low=0, high=1, size=(size, size)),
@@ -96,7 +100,7 @@ class TestMaskedCircuits:
             parameters=pnp.random.uniform(low=0, high=1, size=(size, size)),
             layers=size,
             wires=size,
-            masks=[(Axis.LAYERS, Mask)],
+            masks=[(Axis.LAYERS, DropoutMask)],
         )
         assert mc.mask.size == size * size
 
@@ -386,7 +390,7 @@ class TestMaskedCircuits:
             parameters=parameters,
             layers=size,
             wires=size,
-            entangling_mask=Mask(shape=(size, size - 1)),
+            entangling_mask=DropoutMask(shape=(size, size - 1)),
         )
 
 
@@ -400,7 +404,7 @@ class TestFreezableMaskedCircuit:
                 parameters=pnp.random.uniform(low=0, high=1, size=(size, size)),
                 layers=size,
                 wires=size,
-                freeze_masks=[(Axis.ENTANGLING, Mask)],
+                freeze_masks=[(Axis.ENTANGLING, DropoutMask)],
             )
 
         mp = FreezableMaskedCircuit.full_circuit(
@@ -408,7 +412,7 @@ class TestFreezableMaskedCircuit:
             layers=size,
             wires=size,
             wire_mask=pnp.ones((size,), dtype=bool),
-            entangling_mask=Mask(shape=(size, size - 1)),
+            entangling_mask=DropoutMask(shape=(size, size - 1)),
         )
         assert mp
 

--- a/tests/test_masks.py
+++ b/tests/test_masks.py
@@ -42,7 +42,7 @@ class TestMask:
     def test_wrong_mode(self):
         mp = Mask((3,))
         with pytest.raises(NotImplementedError):
-            mp.perturb(mode=10)
+            mp.perturb(mode=10, amount=1)
 
     def test_perturbation(self):
         size = 3

--- a/tests/test_masks.py
+++ b/tests/test_masks.py
@@ -3,23 +3,23 @@ import pytest
 
 import pennylane.numpy as pnp
 
-from maskit._masks import Mask, PerturbationMode
+from maskit._masks import DropoutMask, PerturbationMode
 
 
 class TestMask:
     def test_init(self):
         size = 3
         with pytest.raises(AssertionError):
-            Mask((size,), mask=pnp.array([True, True, False, False]))
+            DropoutMask((size,), mask=pnp.array([True, True, False, False]))
         with pytest.raises(AssertionError):
-            Mask((size,), mask=pnp.array([0, 1, 3]))
+            DropoutMask((size,), mask=pnp.array([0, 1, 3]))
         preset = [False, True, False]
-        mp = Mask((size,), mask=pnp.array(preset))
+        mp = DropoutMask((size,), mask=pnp.array(preset))
         assert pnp.array_equal(mp.mask, preset)
 
     def test_setting(self):
         size = 3
-        mp = Mask((size,))
+        mp = DropoutMask((size,))
         assert mp
         assert len(mp.mask) == mp.mask.size
         assert pnp.sum(mp.mask) == 0
@@ -40,13 +40,13 @@ class TestMask:
             mp[1, 2] = True
 
     def test_wrong_mode(self):
-        mp = Mask((3,))
+        mp = DropoutMask((3,))
         with pytest.raises(NotImplementedError):
             mp.perturb(mode=10, amount=1)
 
     def test_perturbation(self):
         size = 3
-        mp = Mask((size,))
+        mp = DropoutMask((size,))
 
         for i in range(1, size + 1):
             mp.perturb(i)
@@ -55,7 +55,7 @@ class TestMask:
 
     def test_percentage_perturbation(self):
         size = 3
-        mp = Mask((size,))
+        mp = DropoutMask((size,))
 
         for i in [0.01, 0.1, 0.5, 0.9]:
             mp.perturb(amount=i)
@@ -64,7 +64,7 @@ class TestMask:
 
     def test_wrong_percentage_perturbation(self):
         size = 3
-        mp = Mask((size,))
+        mp = DropoutMask((size,))
 
         for i in [1.1, 1.5, 3.1]:
             mp.perturb(amount=i)
@@ -72,13 +72,13 @@ class TestMask:
             mp.clear()
 
     def test_negative_perturbation(self):
-        mp = Mask((3,))
+        mp = DropoutMask((3,))
         with pytest.raises(AssertionError):
             mp.perturb(amount=-1)
 
     def test_perturbation_remove_add(self):
         size = 3
-        mp = Mask((size,))
+        mp = DropoutMask((size,))
 
         for amount in [random.randrange(size), 0, size, size + 1]:
             mp.perturb(amount=amount, mode=PerturbationMode.RESET)
@@ -89,7 +89,7 @@ class TestMask:
 
     def test_perturbation_invert_remove(self):
         size = 3
-        mp = Mask((size,))
+        mp = DropoutMask((size,))
 
         for amount in [random.randrange(size), 0, size, size + 1]:
             mp.perturb(amount=amount, mode=PerturbationMode.INVERT)
@@ -99,7 +99,7 @@ class TestMask:
 
     def test_perturbation_add_remove(self):
         size = 3
-        mp = Mask((size,))
+        mp = DropoutMask((size,))
 
         for amount in [random.randrange(size), 0, size, size + 1]:
             mp.perturb(amount=amount, mode=PerturbationMode.SET)
@@ -116,7 +116,7 @@ class TestMask:
     )
     def test_perturbation_mode(self, mode):
         size = 3
-        mp = Mask((size,))
+        mp = DropoutMask((size,))
 
         for amount in [0, size, size + 1]:
             mp.perturb(amount=amount, mode=mode[0])
@@ -125,7 +125,7 @@ class TestMask:
 
     def test_shrink(self):
         size = 3
-        mp = Mask((size,))
+        mp = DropoutMask((size,))
 
         for amount in range(size + 1):
             mp[:] = True
@@ -134,7 +134,7 @@ class TestMask:
 
     def test_shrink_nd(self):
         size = 3
-        mp = Mask((size, size - 1))
+        mp = DropoutMask((size, size - 1))
         for amount in range(mp.mask.size + 1):
             mp[:] = True
             mp.shrink(amount)
@@ -142,7 +142,7 @@ class TestMask:
 
     def test_copy(self):
         size = 3
-        mp = Mask((size,))
+        mp = DropoutMask((size,))
         new_mp = mp.copy()
         mp[0] = True
         assert pnp.sum(mp.mask) > pnp.sum(new_mp.mask)
@@ -150,7 +150,7 @@ class TestMask:
 
     def test_apply_mask(self):
         size = 3
-        mp = Mask((size,))
+        mp = DropoutMask((size,))
         with pytest.raises(IndexError):
             mp.apply_mask(pnp.ones((size - 1, size)))
         mp.mask[1] = True

--- a/tests/test_masks.py
+++ b/tests/test_masks.py
@@ -50,7 +50,7 @@ class TestMask:
 
         for i in range(1, size + 1):
             mp.perturb(i)
-            mp.perturb(i, mode=PerturbationMode.REMOVE)
+            mp.perturb(i, mode=PerturbationMode.RESET)
             assert pnp.sum(mp.mask) == 0
 
     def test_percentage_perturbation(self):
@@ -81,9 +81,9 @@ class TestMask:
         mp = Mask((size,))
 
         for amount in [random.randrange(size), 0, size, size + 1]:
-            mp.perturb(amount=amount, mode=PerturbationMode.REMOVE)
+            mp.perturb(amount=amount, mode=PerturbationMode.RESET)
             assert pnp.sum(mp.mask) == 0
-            mp.perturb(amount=amount, mode=PerturbationMode.ADD)
+            mp.perturb(amount=amount, mode=PerturbationMode.SET)
             assert pnp.sum(mp.mask) == min(amount, size)
             mp.clear()
 
@@ -94,7 +94,7 @@ class TestMask:
         for amount in [random.randrange(size), 0, size, size + 1]:
             mp.perturb(amount=amount, mode=PerturbationMode.INVERT)
             reversed_amount = pnp.sum(mp.mask).unwrap()  # unwrap tensor
-            mp.perturb(amount=reversed_amount, mode=PerturbationMode.REMOVE)
+            mp.perturb(amount=reversed_amount, mode=PerturbationMode.RESET)
             assert pnp.sum(mp.mask) == 0
 
     def test_perturbation_add_remove(self):
@@ -102,15 +102,15 @@ class TestMask:
         mp = Mask((size,))
 
         for amount in [random.randrange(size), 0, size, size + 1]:
-            mp.perturb(amount=amount, mode=PerturbationMode.ADD)
+            mp.perturb(amount=amount, mode=PerturbationMode.SET)
             assert pnp.sum(mp.mask) == min(amount, size)
-            mp.perturb(amount=amount, mode=PerturbationMode.REMOVE)
+            mp.perturb(amount=amount, mode=PerturbationMode.RESET)
             assert pnp.sum(mp.mask) == 0
 
     @pytest.mark.parametrize(
         "mode",
         [
-            (PerturbationMode.ADD, PerturbationMode.INVERT),
+            (PerturbationMode.SET, PerturbationMode.INVERT),
             (PerturbationMode.INVERT, PerturbationMode.INVERT),
         ],
     )

--- a/tests/test_masks.py
+++ b/tests/test_masks.py
@@ -160,11 +160,6 @@ class TestDropoutMask:
 
 
 class TestValueMask:
-    def test_init(self):
-        vm = ValueMask((3,))
-        assert vm
-        assert vm.mask.dtype == float
-
     def test_apply_mask(self):
         size = 3
         mp = ValueMask((size,))

--- a/tests/test_masks.py
+++ b/tests/test_masks.py
@@ -173,7 +173,6 @@ class TestValueMask:
         mp.mask[1] = 1
         result = mp.apply_mask(pnp.ones((size,), dtype=float))
         assert pnp.sum(mp.mask) == 1
-        print(result)
         assert pnp.sum(result) == size + 1
         mp.mask[1] = -1
         result = mp.apply_mask(pnp.ones((size,), dtype=float))

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -27,7 +27,7 @@ class TestLBFGSBOptimizer:
         mp_step = mp.copy()
         circuit = qml.QNode(
             plain_variational_circuit,
-            device(mp.mask_for_axis(Axis.WIRES).size),
+            device(mp.mask(Axis.WIRES).size),
         )
 
         def cost_fn(params):
@@ -57,7 +57,7 @@ class TestLBFGSBOptimizer:
         mp_original = mp.copy()
         circuit = qml.QNode(
             plain_variational_circuit,
-            device(mp.mask_for_axis(Axis.WIRES).size),
+            device(mp.mask(Axis.WIRES).size),
         )
 
         def cost_fn(params):
@@ -77,9 +77,7 @@ class TestLBFGSBOptimizer:
         optimizer = L_BFGS_B()
         mp = create_circuit(3, layer_size=2)
         mp_step = mp.copy()
-        circuit = qml.QNode(
-            variational_circuit, device(mp.mask_for_axis(Axis.WIRES).size)
-        )
+        circuit = qml.QNode(variational_circuit, device(mp.mask(Axis.WIRES).size))
 
         def cost_fn(params, masked_circuit=None):
             return cost(
@@ -105,9 +103,7 @@ class TestLBFGSBOptimizer:
         optimizer = L_BFGS_B()
         ensemble = Ensemble(dropout=RANDOM)
         mp = create_circuit(3, layer_size=2)
-        circuit = qml.QNode(
-            variational_circuit, device(mp.mask_for_axis(Axis.WIRES).size)
-        )
+        circuit = qml.QNode(variational_circuit, device(mp.mask(Axis.WIRES).size))
 
         def cost_fn(params, masked_circuit=None):
             return cost(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -53,25 +53,19 @@ def create_freezable_circuit(size: int, layer_size: int = 1):
 
 def variational_circuit(params, masked_circuit: MaskedCircuit = None):
     full_parameters = masked_circuit.expanded_parameters(params)
-    for layer, layer_hidden in enumerate(masked_circuit.mask_for_axis(Axis.LAYERS)):
+    for layer, layer_hidden in enumerate(masked_circuit.mask(Axis.LAYERS)):
         if not layer_hidden:
-            for wire, wire_hidden in enumerate(
-                masked_circuit.mask_for_axis(Axis.WIRES)
-            ):
+            for wire, wire_hidden in enumerate(masked_circuit.mask(Axis.WIRES)):
                 if not wire_hidden:
-                    if not masked_circuit.mask_for_axis(Axis.PARAMETERS)[layer][wire][
-                        0
-                    ]:
+                    if not masked_circuit.mask(Axis.PARAMETERS)[layer][wire][0]:
                         qml.RX(full_parameters[layer][wire][0], wires=wire)
-                    if not masked_circuit.mask_for_axis(Axis.PARAMETERS)[layer][wire][
-                        1
-                    ]:
+                    if not masked_circuit.mask(Axis.PARAMETERS)[layer][wire][1]:
                         qml.RY(full_parameters[layer][wire][1], wires=wire)
-            for wire in range(0, masked_circuit.mask_for_axis(Axis.LAYERS).size - 1, 2):
+            for wire in range(0, masked_circuit.mask(Axis.LAYERS).size - 1, 2):
                 qml.CZ(wires=[wire, wire + 1])
-            for wire in range(1, masked_circuit.mask_for_axis(Axis.LAYERS).size - 1, 2):
+            for wire in range(1, masked_circuit.mask(Axis.LAYERS).size - 1, 2):
                 qml.CZ(wires=[wire, wire + 1])
-    return qml.probs(wires=range(len(masked_circuit.mask_for_axis(Axis.WIRES))))
+    return qml.probs(wires=range(len(masked_circuit.mask(Axis.WIRES))))
 
 
 def plain_variational_circuit(params):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,8 +1,8 @@
 import pennylane as qml
 import pennylane.numpy as pnp
 
-from maskit._masks import PerturbationAxis as Axis
-from maskit._masked_circuits import FreezableMaskedCircuit, MaskedCircuit
+from maskit._masks import PerturbationAxis as Axis, DropoutMask, FreezeMask
+from maskit._masked_circuits import MaskedCircuit
 
 
 def device(wires: int):
@@ -34,9 +34,21 @@ def create_freezable_circuit(size: int, layer_size: int = 1):
         parameters = pnp.random.uniform(
             low=-pnp.pi, high=pnp.pi, size=(size, size, layer_size)
         )
-    return FreezableMaskedCircuit.full_circuit(
-        parameters=parameters, layers=size, wires=size
+    return MaskedCircuit(
+        parameters=parameters,
+        layers=size,
+        wires=size,
+        masks=(
+            (axis, mask_type)
+            for axis in Axis
+            if axis is not Axis.ENTANGLING
+            for mask_type in [DropoutMask, FreezeMask]
+        ),
     )
+    # TODO: remove me
+    # return FreezableMaskedCircuit.full_circuit(
+    #     parameters=parameters, layers=size, wires=size
+    # )
 
 
 def variational_circuit(params, masked_circuit: MaskedCircuit = None):


### PR DESCRIPTION
This PR implements a new kind of _mask_ allowing to change values of underlying parameters as described in #48. The change is not as trivial as adding a new `PerturbationMode`. This would require to either extend `perturb` with another parameter (that wouldn't have a purpose for the other modes) or to introduce another method. This in turn might separate the behaviour too much from the functioning of the masks.

I therefore introduce a `Mask` interface here. We now support different versions of `Mask`s including the standard one that does... yes, masking – it is currently called `DropoutMask`; and a kind of `ValueMask` (proper naming is still process) that will allow to shift underlying parameter values. `Mask`s can be added for available `PurturbationAxis`. This concept will allow to layer the different types of `Mask`s.

As the current `PerturbationMode`s did not properly represent what could be done with different types of masks, I propose to rename them. I currently picked `SET`, `RESET` and `INVERT`. I am still not very happy as in the case of a `ValueMask` the `SET` is interpreted to set the value to a specific value. However, we might even consider adding given values what would currently not be reflected. I am still unsure about this but would first go with setting a value. The other option might be implemented later on. 

Still some things to be done:

- [x] renaming of perturbation modes
- [x] add a new mask for values
- [x] distinguish different mask types in `MaskedCircuit`

The documentation will properly be extended in PR #39.

Closes #48.