### PR TITLE
Add basic functionality for validation set

### DIFF
--- a/main.py
+++ b/main.py
@@ -318,9 +318,7 @@ def test(
     data: Optional[np.ndarray] = None,
     target: Optional[np.ndarray] = None,
 ):
-    if data is None or target is None:
-        pass
-    elif data is not None and target is not None:
+    if data is not None and target is not None:
         return loss_and_accuracy(
             circuit,
             masked_circuit=masked_circuit,

--- a/main.py
+++ b/main.py
@@ -386,17 +386,11 @@ if __name__ == "__main__":
     if logging_activated:
         train = log_results(
             train,
-            exclude=(
-                "data",
-                "target",
-            ),
+            exclude=("data", "target", "validation_data", "validation_target"),
         )
         test = log_results(
             test,
-            exclude=(
-                "data",
-                "target",
-            ),
+            exclude=("data", "target"),
         )
     seed = train_params.pop("seed", 1337)
     np.random.seed(seed)

--- a/maskit/datasets/__init__.py
+++ b/maskit/datasets/__init__.py
@@ -10,6 +10,7 @@ def load_data(
     dataset: str,
     train_size: int = 100,
     test_size: int = 50,
+    validation_size: int = 0,
     shuffle: Union[bool, int] = 1337,
     classes: Tuple[int, ...] = (6, 9),
     wires: int = 4,
@@ -37,6 +38,7 @@ def load_data(
             classes=classes,
             train_size=train_size,
             test_size=test_size,
+            validation_size=validation_size,
             shuffle=shuffle,
         )
     elif dataset == "circles":
@@ -51,14 +53,18 @@ def load_data(
         f"{result.train_target.shape[1]} classes"
     )
     if difference > 0:
-        # extend train and test target arrays
+        # extend train, validation and test target arrays
         new_train_target = pad_data(result.train_target, 1, difference)
         new_test_target = pad_data(result.test_target, 1, difference)
+        if result.validation_target is not None and len(result.validation_target) > 0:
+            new_validation_target = pad_data(result.validation_target, 1, difference)
+        else:
+            new_validation_target = None
         result = DataSet(
             result.train_data,
             new_train_target,
-            None,
-            None,
+            result.validation_data,
+            new_validation_target,
             result.test_data,
             new_test_target,
         )

--- a/maskit/datasets/__init__.py
+++ b/maskit/datasets/__init__.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Optional
+from typing import Tuple, Optional, Union
 
 from maskit.datasets.circles import circles
 from maskit.datasets.iris import iris
@@ -10,7 +10,7 @@ def load_data(
     dataset: str,
     train_size: int = 100,
     test_size: int = 50,
-    shuffle: bool = True,
+    shuffle: Union[bool, int] = 1337,
     classes: Tuple[int, ...] = (6, 9),
     wires: int = 4,
     target_length: Optional[int] = None,
@@ -22,7 +22,7 @@ def load_data(
         Available datasets are: iris, mnist and circles.
     :param train_size: Size of the training dataset
     :param test_size: Size of the testing dataset
-    :param shuffle: if the dataset should be shuffled
+    :param shuffle: if the dataset should be shuffled, used also as a seed
     :param classes: which numbers of the mnist dataset should be included
     :param wires: number of wires in the circuit
     :param target_length: Normalised length of target arrays

--- a/maskit/datasets/__init__.py
+++ b/maskit/datasets/__init__.py
@@ -30,11 +30,17 @@ def load_data(
     :raises ValueError: Raised if a not supported dataset is requested
     """
     if dataset == "iris":
-        result = iris(train_size, test_size, shuffle)
+        result = iris(train_size=train_size, test_size=test_size, shuffle=shuffle)
     elif dataset == "mnist":
-        result = mnist(wires, classes, train_size, test_size, shuffle)
+        result = mnist(
+            wires=wires,
+            classes=classes,
+            train_size=train_size,
+            test_size=test_size,
+            shuffle=shuffle,
+        )
     elif dataset == "circles":
-        result = circles(train_size, test_size, shuffle)
+        result = circles(train_size=train_size, test_size=test_size, shuffle=shuffle)
     else:
         raise ValueError(f"Unknown dataset: {dataset}")
     if target_length is None:
@@ -49,6 +55,11 @@ def load_data(
         new_train_target = pad_data(result.train_target, 1, difference)
         new_test_target = pad_data(result.test_target, 1, difference)
         result = DataSet(
-            result.train_data, new_train_target, result.test_data, new_test_target
+            result.train_data,
+            new_train_target,
+            None,
+            None,
+            result.test_data,
+            new_test_target,
         )
     return result

--- a/maskit/datasets/circles.py
+++ b/maskit/datasets/circles.py
@@ -9,4 +9,4 @@ def circles(train_size=100, test_size=50, shuffle=True) -> DataSet:
 
     y_train, y_test = one_hot(y_train, 2), one_hot(y_test, 2)
 
-    return DataSet(x_train, y_train, x_test, y_test)
+    return DataSet(x_train, y_train, None, None, x_test, y_test)

--- a/maskit/datasets/iris.py
+++ b/maskit/datasets/iris.py
@@ -27,4 +27,4 @@ def iris(train_size=100, test_size=50, shuffle=True) -> DataSet:
     y_train = one_hot(y_train, 3)
     y_test = one_hot(y_test, 3)
 
-    return DataSet(x_train, y_train, x_test, y_test)
+    return DataSet(x_train, y_train, None, None, x_test, y_test)

--- a/maskit/datasets/mnist.py
+++ b/maskit/datasets/mnist.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List, Tuple, Union
 import tensorflow as tf
 from sklearn.decomposition import PCA
 from pennylane import numpy as np
@@ -77,7 +77,7 @@ def mnist(
     train_size: int = 100,
     validation_size: int = 0,
     test_size: int = 50,
-    shuffle: bool = True,
+    shuffle: Union[bool, int] = 1337,
 ) -> DataSet:
     (x_train, y_train), (x_test, y_test) = tf.keras.datasets.mnist.load_data()
     train_size = min(train_size, MAX_TRAIN_SAMPLES - validation_size)
@@ -85,7 +85,7 @@ def mnist(
     test_size = min(test_size, MAX_TEST_SAMPLES)
 
     if shuffle:
-        x_train, y_train = skl_shuffle(x_train, y_train)
+        x_train, y_train = skl_shuffle(x_train, y_train, random_state=shuffle)
 
     # split validation set from train set
     split_point = len(x_train) - (5000 if validation_size > 0 else 0)

--- a/maskit/datasets/mnist.py
+++ b/maskit/datasets/mnist.py
@@ -39,7 +39,7 @@ def downscale(x_data, y_data, size) -> Tuple[np.ndarray, np.ndarray]:
     :param y_data: Target data
     :param size: Maximum number of data to prepare
     """
-    data_index: List[bool] = np.zeros(len(y_data), dtype=bool)
+    data_index: List[bool] = [False] * len(y_data)
     result_x: List[np.ndarray] = []
     result_x_set = set()
     for index, image in enumerate(x_data):

--- a/maskit/datasets/mnist.py
+++ b/maskit/datasets/mnist.py
@@ -19,10 +19,6 @@ def reduce_image(x: np.ndarray) -> np.ndarray:
     return x / 255
 
 
-def convert_to_binary(x: np.ndarray) -> np.ndarray:
-    return (x < 0.5).astype(int)
-
-
 def convert_label(y: int, classes: List[int]) -> List[float]:
     assert y in classes
     return [1.0 if the_class == y else 0.0 for the_class in classes]
@@ -49,7 +45,7 @@ def downscale(x_data, y_data, size) -> Tuple[np.ndarray, np.ndarray]:
     for index, image in enumerate(x_data):
         if len(result_x) >= size:
             break
-        reduced_image = convert_to_binary(reduce_image(image))
+        reduced_image = reduce_image(image)
         previous_len = len(result_x_set)
         result_x_set.add(str(reduced_image))
         if len(result_x_set) <= previous_len:  # next if contradicting
@@ -89,11 +85,12 @@ def mnist(
     test_size = min(test_size, MAX_TEST_SAMPLES)
 
     # split validation set from train set
+    split_point = len(x_train) - (5000 if validation_size > 0 else 0)
     x_train, y_train, x_validation, y_validation = (
-        x_train[:-5000],
-        y_train[:-5000],
-        x_train[-5000:],
-        y_train[-5000:],
+        x_train[:split_point],
+        y_train[:split_point],
+        x_train[split_point:],
+        y_train[split_point:],
     )
 
     x_train, y_train = prepare_data(x_train, y_train, train_size, classes)

--- a/maskit/datasets/mnist.py
+++ b/maskit/datasets/mnist.py
@@ -84,6 +84,9 @@ def mnist(
     validation_size = min(validation_size, MAX_TRAIN_SAMPLES - train_size)
     test_size = min(test_size, MAX_TEST_SAMPLES)
 
+    if shuffle:
+        x_train, y_train = skl_shuffle(x_train, y_train)
+
     # split validation set from train set
     split_point = len(x_train) - (5000 if validation_size > 0 else 0)
     x_train, y_train, x_validation, y_validation = (
@@ -98,10 +101,6 @@ def mnist(
         x_validation, y_validation, validation_size, classes
     )
     x_test, y_test = prepare_data(x_test, y_test, test_size, classes)
-
-    if shuffle:
-        x_train, y_train = skl_shuffle(x_train, y_train)
-        # TODO: also shuffle validation data?
 
     pca = apply_PCA(wires, x_train)
     x_train = pca.transform(x_train)

--- a/maskit/datasets/mnist.py
+++ b/maskit/datasets/mnist.py
@@ -1,14 +1,15 @@
-from typing import List
+from typing import List, Tuple
 import tensorflow as tf
-import collections
 from sklearn.decomposition import PCA
 from pennylane import numpy as np
 from sklearn.preprocessing import minmax_scale
+from sklearn.utils import shuffle as skl_shuffle
 
 from maskit.datasets.utils import DataSet
 
-MAX_TRAIN_SAMPLES = 11471
-MAX_TEST_SAMPLES = 1952
+# ignore filtering on classes
+MAX_TRAIN_SAMPLES = 60000
+MAX_TEST_SAMPLES = 10000
 
 
 def reduce_image(x: np.ndarray) -> np.ndarray:
@@ -18,23 +19,8 @@ def reduce_image(x: np.ndarray) -> np.ndarray:
     return x / 255
 
 
-def remove_contradicting(xs: np.ndarray, ys: np.ndarray) -> np.ndarray:
-    mapping = collections.defaultdict(set)
-    for x, y in zip(xs, ys):
-        mapping[str(x)].add(y)
-
-    return zip(*((x, y) for x, y in zip(xs, ys) if len(mapping[str(x)]) == 1))
-
-
 def convert_to_binary(x: np.ndarray) -> np.ndarray:
-    x_new = []
-    for a in x:
-        c = (a < 0.5).astype(int)
-        c = np.expand_dims(c, axis=0)
-        x_new.append(c)
-
-    x_new = np.concatenate(x_new)
-    return x_new
+    return (x < 0.5).astype(int)
 
 
 def convert_label(y: int, classes: List[int]) -> List[float]:
@@ -48,51 +34,95 @@ def apply_PCA(wires: int, x_train: np.ndarray):
     return pca
 
 
+def downscale(x_data, y_data, size) -> Tuple[np.ndarray, np.ndarray]:
+    """
+    This function does several things including the reduction of image size,
+    conversion to binary as well as removal of duplicates.
+
+    :param x_data: Input data
+    :param y_data: Target data
+    :param size: Maximum number of data to prepare
+    """
+    data_index: List[bool] = np.zeros(len(y_data), dtype=bool)
+    result_x: List[np.ndarray] = []
+    result_x_set = set()
+    for index, image in enumerate(x_data):
+        if len(result_x) >= size:
+            break
+        reduced_image = convert_to_binary(reduce_image(image))
+        previous_len = len(result_x_set)
+        result_x_set.add(str(reduced_image))
+        if len(result_x_set) <= previous_len:  # next if contradicting
+            continue
+        result_x.append(reduced_image)
+        data_index[index] = True
+    return (np.array(result_x), y_data[data_index])
+
+
+def prepare_data(
+    x_data: np.ndarray, y_data: np.ndarray, size, classes
+) -> Tuple[np.ndarray, np.ndarray]:
+    data_index = np.isin(y_data, classes)
+    x_data, y_data = x_data[data_index], y_data[data_index]
+    x_data, y_data = downscale(x_data, y_data, size)
+    y_data = np.array([convert_label(y, classes) for y in y_data])
+    try:
+        x_data = np.reshape(
+            x_data, (x_data.shape[0], x_data.shape[1] * x_data.shape[2])
+        )
+    except IndexError:
+        pass
+    return (x_data, y_data)
+
+
 def mnist(
-    wires=4, classes=(6, 9), train_size=100, test_size=50, shuffle=True
+    wires: int = 4,
+    classes=(6, 9),
+    train_size: int = 100,
+    validation_size: int = 0,
+    test_size: int = 50,
+    shuffle: bool = True,
 ) -> DataSet:
     (x_train, y_train), (x_test, y_test) = tf.keras.datasets.mnist.load_data()
-    train_size = min(train_size, MAX_TRAIN_SAMPLES)
+    train_size = min(train_size, MAX_TRAIN_SAMPLES - validation_size)
+    validation_size = min(validation_size, MAX_TRAIN_SAMPLES - train_size)
     test_size = min(test_size, MAX_TEST_SAMPLES)
 
-    x_train, y_train = zip(*((x, y) for x, y in zip(x_train, y_train) if y in classes))
-    x_test, y_test = zip(*((x, y) for x, y in zip(x_test, y_test) if y in classes))
-
-    x_train = [reduce_image(x) for x in x_train]
-    x_test = [reduce_image(x) for x in x_test]
-
-    x_train, y_train = remove_contradicting(x_train, y_train)
-    x_test, y_test = remove_contradicting(x_test, y_test)
-
-    x_train, y_train = x_train[:train_size], y_train[:train_size]
-    x_test, y_test = x_test[:test_size], y_test[:test_size]
-
-    x_train = convert_to_binary(x_train)
-    x_test = convert_to_binary(x_test)
-    y_train = [convert_label(y, classes) for y in y_train]
-    y_test = [convert_label(y, classes) for y in y_test]
-
-    x_train = np.reshape(
-        x_train, (x_train.shape[0], x_train.shape[1] * x_train.shape[2])
+    # split validation set from train set
+    x_train, y_train, x_validation, y_validation = (
+        x_train[:-5000],
+        y_train[:-5000],
+        x_train[-5000:],
+        y_train[-5000:],
     )
-    x_test = np.reshape(x_test, (x_test.shape[0], x_test.shape[1] * x_test.shape[2]))
+
+    x_train, y_train = prepare_data(x_train, y_train, train_size, classes)
+    x_validation, y_validation = prepare_data(
+        x_validation, y_validation, validation_size, classes
+    )
+    x_test, y_test = prepare_data(x_test, y_test, test_size, classes)
+
+    if shuffle:
+        x_train, y_train = skl_shuffle(x_train, y_train)
+        # TODO: also shuffle validation data?
 
     pca = apply_PCA(wires, x_train)
     x_train = pca.transform(x_train)
+    x_train = minmax_scale(x_train, (0, 2 * np.pi))
+    if len(x_validation) > 0:
+        x_validation = pca.transform(x_validation)
+        x_validation = minmax_scale(x_validation, (0, 2 * np.pi))
     x_test = pca.transform(x_test)
+    x_test = minmax_scale(x_test, (0, 2 * np.pi))
 
-    if shuffle:
-        c = list(zip(x_train, y_train))
-        np.random.shuffle(c)
-        x_train, y_train = zip(*c)
+    return DataSet(x_train, y_train, x_validation, y_validation, x_test, y_test)
 
-    n_x_train = len(x_train)
-    data_combined = np.concatenate((np.array(x_train), np.array(x_test)))
 
-    data_combined = minmax_scale(data_combined, (0, 2 * np.pi))
-    x_train = data_combined[:n_x_train][:]
-    x_test = data_combined[n_x_train:][:]
+if __name__ == "__main__":
+    import timeit
 
-    y_train, y_test = np.array(y_train), np.array(y_test)
-
-    return DataSet(x_train, y_train, x_test, y_test)
+    print(
+        timeit.timeit(
+            "mnist(validation_size=50)", setup="from __main__ import mnist", number=1
+        )
+    )

--- a/maskit/datasets/utils.py
+++ b/maskit/datasets/utils.py
@@ -23,5 +23,7 @@ def pad_data(data: np.ndarray, axis: int, padding: int) -> np.ndarray:
 class DataSet(NamedTuple):
     train_data: Optional[np.ndarray]
     train_target: Optional[np.ndarray]
+    validation_data: Optional[np.ndarray]
+    validation_target: Optional[np.ndarray]
     test_data: Optional[np.ndarray]
     test_target: Optional[np.ndarray]

--- a/maskit/log_results.py
+++ b/maskit/log_results.py
@@ -56,6 +56,7 @@ def log_results(executor: CJ, exclude: Tuple[str, ...]) -> CJ:
                 out_file,
                 default=serialize,
             )
+            out_file.write("\n")
         return result
 
     return wrapper

--- a/tests/test_load_data.py
+++ b/tests/test_load_data.py
@@ -48,7 +48,7 @@ class TestLoadData:
         assert len(data.test_target[0]) == 2
 
     def test_mnist_basic(self):
-        classes = [6, 7, 8]
+        classes = (6, 7, 8)
         data = load_data(
             "mnist",
             wires=5,


### PR DESCRIPTION
This PR adds basic functionality to also generate a validation set for the mnist dataset.
Further, this PR improves the data loading by removing duplicates from the different sets of train, validation and test sets.
I also changed some of the methods to improve the speed of data loading.

And one more thing: I did hide the writing of newlines after each json object while logging the results.

Closes #61, closes #60.