### PR TITLE
Update requirements to pennylane v0.18

### DIFF
--- a/main.py
+++ b/main.py
@@ -28,7 +28,7 @@ from maskit.ensembles import (
 def get_device(sim_local: bool, wires: int, shots: Optional[int] = None):
     assert sim_local, "Currently only local simulation is supported"
     if sim_local:
-        dev = qml.device("default.qubit", wires=wires, shots=shots)
+        dev = qml.device("lightning.qubit", wires=wires, shots=shots)
     return dev
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dynamic = ["version", "description"]
 license = {file = "LICENSE"}
 keywords = ["quantum computing",]
 dependencies = [
-    "pennylane ~= 0.16.0",
+    "pennylane ~= 0.18.0",
     "typing_extensions",
 ]
 


### PR DESCRIPTION
This PR updates the requirements to PennyLane ~= 0.18.
Further, we now use the `lightning.qubit` device as default device as current tests show that it is faster when using `shots!=None`.

Closes #37.